### PR TITLE
returning account_id as string when authorizing

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/AccessToken.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/AccessToken.java
@@ -2,6 +2,8 @@ package com.hello.suripu.core.oauth;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import org.joda.time.DateTime;
@@ -28,7 +30,8 @@ public class AccessToken {
     @JsonIgnore
     public final DateTime createdAt;
 
-    @JsonIgnore
+    @JsonProperty("account_id")
+    @JsonSerialize(using = ToStringSerializer.class)
     public final Long accountId;
 
     @JsonIgnore


### PR DESCRIPTION
**CHANGES**
1. updated model to not ignore accountId when serializing json and return it as a String, as discussed, instead
