### PR TITLE
Endpoint to retrieve owner-accounts by device ID

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/DeviceResources.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/DeviceResources.java
@@ -229,4 +229,16 @@ public class DeviceResources {
 
         return inactiveDevices;
     }
+
+    @Timed
+    @GET
+    @Path("/{device_id}/accounts")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ImmutableList<Account> getAccountsByDeviceIDs(@Scope(OAuthScope.ADMINISTRATION_READ) AccessToken accessToken,
+                                                @QueryParam("max_devices") Long maxDevices,
+                                                @PathParam("device_id") String deviceId) {
+        LOGGER.debug("Searching accounts who have used device {}", deviceId);
+        final ImmutableList<Account> accounts = deviceDAO.getAccountsByDevices(deviceId, maxDevices);
+        return accounts;
+    }
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDAO.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDAO.java
@@ -2,9 +2,11 @@ package com.hello.suripu.core.db;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.hello.suripu.core.db.mappers.AccountMapper;
 import com.hello.suripu.core.db.mappers.DeviceAccountPairMapper;
 import com.hello.suripu.core.db.mappers.DeviceInactiveMapper;
 import com.hello.suripu.core.db.mappers.DeviceStatusMapper;
+import com.hello.suripu.core.models.Account;
 import com.hello.suripu.core.models.DeviceAccountPair;
 import com.hello.suripu.core.models.DeviceInactive;
 import com.hello.suripu.core.models.DeviceStatus;
@@ -114,5 +116,13 @@ public interface DeviceDAO {
     ImmutableList<DeviceInactive> getInactiveDevice(
             @Bind("start_time") final DateTime startTime,
             @Bind("inactive_hours") final Integer inactiveHours
+    );
+
+    @RegisterMapper(AccountMapper.class)
+    @SingleValueResult(Account.class)
+    @SqlQuery("SELECT * FROM account_device_map as m JOIN accounts as a ON (a.id = m.account_id) WHERE m.device_name = :device_id LIMIT :max_devices;")
+    ImmutableList<Account> getAccountsByDevices(
+            @Bind("device_id") final String deviceId,
+            @Bind("max_devices") final Long maxDevices
     );
 }


### PR DESCRIPTION
- To help detect in-trouble users in corporation with /troubleshoot
  (i.e. who have been inactive)
- To help debug by in corporation with /debug_log, provide user specs
  of device owners
  @pims 
