### PR TITLE
Fix the bug in wakeup period cutoff and alignment

### DIFF
--- a/suripu-algorithm/src/main/java/com/hello/suripu/algorithm/sleep/AwakeDetectionAlgorithm.java
+++ b/suripu-algorithm/src/main/java/com/hello/suripu/algorithm/sleep/AwakeDetectionAlgorithm.java
@@ -52,7 +52,7 @@ public class AwakeDetectionAlgorithm extends SleepDetectionAlgorithm {
                 dateOfTheNightLocalUTC.withTimeAtStartOfDay().plusDays(1).plusHours(4));
 
         final AmplitudeDataPreprocessor cutAfter4am = new DataCutter(dateOfTheNightLocalUTC.withTimeAtStartOfDay().plusDays(1).plusHours(4),
-                dateOfTheNightLocalUTC.withTimeAtStartOfDay().plusDays(1)/*.plusHours(12)*/);
+                dateOfTheNightLocalUTC.withTimeAtStartOfDay().plusDays(1).plusHours(12));
 
         final ImmutableList<AmplitudeData> fallAsleepPeriodData = cutBefore4am.process(smoothedData);
         final ImmutableList<AmplitudeData> wakeUpPeriodData = cutAfter4am.process(smoothedData);
@@ -89,8 +89,8 @@ public class AwakeDetectionAlgorithm extends SleepDetectionAlgorithm {
             // Step 3.3: Generate wake-up period by selected threshold.
             final Segment wakeUpSegment = getAwakeSegment(sharpenWakeUpPeriodData, wakeUpThreshold, PaddingMode.PAD_EARLY);
             if(wakeUpSegment != null) {
-                // Set teh end of sleeping period as the start of wake-up period.
-                sleepSegment.setEndTimestamp(wakeUpSegment.getStartTimestamp());
+                // Set the end of sleeping period as the end of wake-up period.
+                sleepSegment.setEndTimestamp(wakeUpSegment.getEndTimestamp());
             }
         }
 


### PR DESCRIPTION
1) The previous setup has no wakeup period cutoff it just took the last motion
2) The previous setup set the end of sleep period to the START of wakeup period detected, which should be the END. The difference is shown by the last blue dot in the image below (It is a 40+ minutes difference):

BEFORE:
![before](https://cloud.githubusercontent.com/assets/406526/5417516/1f57d638-81ef-11e4-8e75-0d2662dc5b18.png)

AFTER:
![after](https://cloud.githubusercontent.com/assets/406526/5417521/30baa59a-81ef-11e4-9fd8-5171167e5415.png)
