### PR TITLE
Change the wakeup time PDF

### DIFF
--- a/suripu-algorithm/src/test/java/MotionScoreAlgorithmTest.java
+++ b/suripu-algorithm/src/test/java/MotionScoreAlgorithmTest.java
@@ -118,7 +118,7 @@ public class MotionScoreAlgorithmTest {
         // Out put from python script:
         /*
         sleep at 2014-12-12 03:03:00, prob: 0.55139287169, amp: 15103
-        wake up at 2014-12-12 07:23:00, prob: 0.548869568492, amp: 1547
+        wake up at 2014-12-12 07:23:00, prob: 0.479932601157, amp: 1547
         */
 
         final DateTime sleepTime = new DateTime(sleepSegment.getStartTimestamp(), DateTimeZone.forOffsetMillis(sleepSegment.getOffsetMillis()));


### PR DESCRIPTION
The wakeup time PDF now starts from the middle of sleep period, so big spikes in the middle is less likely to be classified as wake up:

Previous PDF and problematic result:
![pang-same-time-pdf](https://cloud.githubusercontent.com/assets/406526/5447032/9d322632-847c-11e4-9082-49148cbda9d4.png)

Corrected result from new PDF:
![pang-half-cut](https://cloud.githubusercontent.com/assets/406526/5447036/aedbfd7c-847c-11e4-9196-0ee62a4cd8b9.png)
