### PR TITLE
Refactor upload interval settings

### DIFF
--- a/suripu-service/src/main/java/com/hello/suripu/service/configuration/SenseUploadConfiguration.java
+++ b/suripu-service/src/main/java/com/hello/suripu/service/configuration/SenseUploadConfiguration.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.Min;
 
 public class SenseUploadConfiguration extends Configuration {
     private static final Integer DEFAULT_NON_PEAK_HOUR_LOWER_BOUND = 11;  // non peak periods start at 11:00:00
-    private static final Integer DEFAULT_NON_PEAK_HOUR_UPPER_BOUND = 20;  // non peak periods end at 20:59:59
+    private static final Integer DEFAULT_NON_PEAK_HOUR_UPPER_BOUND = 22;  // non peak periods end at 22:59:59
     private static final Boolean DEFAULT_WEEK_DAYS_ONLY = true;           // weekends are treated as peak periods
     private static final Integer DEFAULT_LONG_INTERVAL = 6;    // minutes
     private static final Integer DEFAULT_SHORT_INTERVAL = 2;   // minutes
@@ -37,7 +37,7 @@ public class SenseUploadConfiguration extends Configuration {
     @JsonProperty("short_interval")
     private Integer shortInterval = DEFAULT_SHORT_INTERVAL;
 
-    public Integer getNonPeakHourLowerbound() {
+    public Integer getNonPeakHourLowerBound() {
         return this.nonPeakHourLowerBound;
     }
 

--- a/suripu-service/src/main/java/com/hello/suripu/service/models/UploadSettings.java
+++ b/suripu-service/src/main/java/com/hello/suripu/service/models/UploadSettings.java
@@ -7,8 +7,6 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 
 public class UploadSettings {
 
@@ -18,42 +16,28 @@ public class UploadSettings {
     private static final Long SUSTAINED_TIME_BETWEEN_NOW_AND_NEXT_ALARM = 60*60*1000L;  // milliseconds
     private static final Integer FASTEST_UPLOAD_INTERVAL = 1; // minute(s)
 
-    public final DateTimeZone userTimeZone;
-    public final Long userNextAlarmTimestamp;
-    public final SenseUploadConfiguration senseUploadConfiguration;
-
-    public UploadSettings(final SenseUploadConfiguration senseUploadConfiguration, final DateTimeZone userTimeZone, final Long userNextAlarmTimestampMillis) {
-        checkNotNull(userTimeZone, "userTimezone can not be null");
-        checkNotNull(userNextAlarmTimestampMillis, "userNextAlarmTimestampMillis can not be null");
-        checkNotNull(senseUploadConfiguration, "senseUploadConfiguration can not be null");
-        this.userTimeZone = userTimeZone;
-        this.userNextAlarmTimestamp = userNextAlarmTimestampMillis;
-        this.senseUploadConfiguration = senseUploadConfiguration;
-    }
-
-    public Integer getUploadIntervalInMinutes() {
-        final Integer unadjustedUploadIntervalInMinutes =  computeUploadIntervalPerUserPerSetting(getUserCurrentDateTime(), senseUploadConfiguration);
-        final Integer adjustedUploadIntervalInMinutes = adjustUploadIntervalInMinutes(unadjustedUploadIntervalInMinutes, userNextAlarmTimestamp);
+    public static Integer getUploadInterval(final DateTime userLocalDateTime, final SenseUploadConfiguration senseUploadConfiguration, final Long userNextAlarmTimestampMillis) {
+        final Integer adjustedUploadIntervalInMinutes = adjustUploadIntervalInMinutes(
+            DateTime.now(DateTimeZone.UTC).getMillis(),
+            computeUploadIntervalPerUserPerSetting(userLocalDateTime, senseUploadConfiguration),
+            userNextAlarmTimestampMillis
+        );
+        LOGGER.debug("Adjusted Upload Interval in Minutes: {}", adjustedUploadIntervalInMinutes);
         return adjustedUploadIntervalInMinutes;
     }
 
-    private DateTime getUserCurrentDateTime() {
-        final DateTime userCurrentDateTime = DateTime.now(this.userTimeZone);
-        return userCurrentDateTime;
-    }
+    public static Integer computeUploadIntervalPerUserPerSetting(final DateTime userLocalDateTime, final SenseUploadConfiguration senseUploadConfiguration) {
 
-    private Integer computeUploadIntervalPerUserPerSetting(final DateTime userCurrentDateTime, final SenseUploadConfiguration senseUploadConfiguration) {
-        final Integer hourOfDay = userCurrentDateTime.getHourOfDay();
+        final Integer hourOfDay = userLocalDateTime.getHourOfDay();
 
-        LOGGER.debug("User Current DateTime - Hour of Day: {}", hourOfDay);
+        LOGGER.debug("User Current DateTime: {}", userLocalDateTime);
 
         // Non peak times are the times whose hours are within the range defined in configuration
-        Boolean isNonPeak = hourOfDay >= senseUploadConfiguration.getNonPeakHourLowerbound() && hourOfDay <= senseUploadConfiguration.getNonPeakHourUpperBound();
+        Boolean isNonPeak = hourOfDay >= senseUploadConfiguration.getNonPeakHourLowerBound() && hourOfDay <= senseUploadConfiguration.getNonPeakHourUpperBound();
 
         // If weekDaysOnly == true, we assume that users could sleep any time during weekends
         if (senseUploadConfiguration.getWeekDaysOnly()) {
-            final Integer dayOfWeek = userCurrentDateTime.getDayOfWeek();
-            LOGGER.debug("User Current DateTime - Day of Week: {}", userCurrentDateTime.dayOfWeek().getAsText());
+            final Integer dayOfWeek = userLocalDateTime.getDayOfWeek();
             isNonPeak = isNonPeak && (dayOfWeek != DateTimeConstants.SATURDAY && dayOfWeek != DateTimeConstants.SUNDAY);
         }
 
@@ -64,30 +48,24 @@ public class UploadSettings {
         return senseUploadConfiguration.getShortInterval();
     }
 
-    private Integer adjustUploadIntervalInMinutes(final Integer standardUploadIntervalInMinutes, final Long userNextAlarmTimestampMillis) {
-        if(userNextAlarmTimestampMillis - DateTime.now(DateTimeZone.UTC).getMillis() < 0){
+    public static Integer adjustUploadIntervalInMinutes(final Long currentTimestampMillis, final Integer standardUploadIntervalInMinutes, final Long userNextAlarmTimestampMillis) {
+
+        if(userNextAlarmTimestampMillis - currentTimestampMillis < 0){
             return standardUploadIntervalInMinutes;
         }
 
-        LOGGER.debug("diff in milliseconds {}", userNextAlarmTimestampMillis - DateTime.now(DateTimeZone.UTC).getMillis());
-        if (userNextAlarmTimestampMillis - DateTime.now(DateTimeZone.UTC).getMillis() <= ALLOWABLE_TIME_BETWEEN_NOW_AND_NEXT_ALARM) {
+        Long timeUntilNextAlarmMillis = userNextAlarmTimestampMillis - currentTimestampMillis;
+
+        if (timeUntilNextAlarmMillis <= ALLOWABLE_TIME_BETWEEN_NOW_AND_NEXT_ALARM) {
             return FASTEST_UPLOAD_INTERVAL;
         }
-        if (userNextAlarmTimestampMillis - DateTime.now(DateTimeZone.UTC).getMillis() >= SUSTAINED_TIME_BETWEEN_NOW_AND_NEXT_ALARM) {
+        if (timeUntilNextAlarmMillis >= SUSTAINED_TIME_BETWEEN_NOW_AND_NEXT_ALARM) {
             return standardUploadIntervalInMinutes;
         }
         return FASTEST_UPLOAD_INTERVAL;
     }
 
-//    public Integer computeUploadIntervalForTests(final DateTime dateTime) {
-//        return computeUploadIntervalPerUserPerSetting(dateTime, new SenseUploadConfiguration());
-//    }
-//
-//    public Integer adjustUploadIntervalForTests(final Integer standardUploadInterval, final Long userNextAlarmTimestamp) {
-//        return adjustUploadIntervalInMinutes(standardUploadInterval, userNextAlarmTimestamp);
-//    }
-
-    public Integer getFastestUploadInterval() {
+    public static Integer getFastestUploadInterval() {
         return FASTEST_UPLOAD_INTERVAL;
     }
 }

--- a/suripu-service/src/main/java/com/hello/suripu/service/resources/ReceiveResource.java
+++ b/suripu-service/src/main/java/com/hello/suripu/service/resources/ReceiveResource.java
@@ -465,9 +465,9 @@ public class ReceiveResource extends BaseResource {
         final DateTimeZone userTimeZone = getUserTimeZone(alarmInfoList);
 
         final Long userNextAlarmTimestamp = alarmBuilder.hasStartTime() ? alarmBuilder.getStartTime() * 1000L : 0;
-        final UploadSettings uploadSettings = new UploadSettings(senseUploadConfiguration, userTimeZone, userNextAlarmTimestamp);
-        final Integer uploadInterval = uploadSettings.getUploadIntervalInMinutes();
-        
+
+        final Integer uploadInterval = UploadSettings.getUploadInterval(DateTime.now(userTimeZone), senseUploadConfiguration, userNextAlarmTimestamp);
+
         responseBuilder.setBatchSize(uploadInterval);
         responseBuilder.setAudioControl(audioControl);
 

--- a/suripu-service/src/test/java/com/hello/suripu/service/models/UploadSettingsTest.java
+++ b/suripu-service/src/test/java/com/hello/suripu/service/models/UploadSettingsTest.java
@@ -1,86 +1,88 @@
 package com.hello.suripu.service.models;
 
 import com.hello.suripu.service.configuration.SenseUploadConfiguration;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class UploadSettingsTest {
 
-    private final static SenseUploadConfiguration senseUploadConfiguration = new SenseUploadConfiguration();
+    private SenseUploadConfiguration senseUploadConfiguration;
 
-    /*
+    @Before
+    public void setUp() {
+        senseUploadConfiguration = new SenseUploadConfiguration();
+
+    }
+
     @Test
     public void testWeekdayNonPeakLowerBound() {
         final DateTime userDateTime = new DateTime(2015, 1, 2, 11, 0, 0);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 2, 14, 0, 0).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalLong = uploadSettings.computeUploadIntervalForTests(userDateTime) == senseUploadConfiguration.getLongInterval();
+        final Boolean isUploadIntervalLong = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration) == senseUploadConfiguration.getLongInterval();
         assertThat(isUploadIntervalLong, is(true));
     }
 
     @Test
     public void testWeekdayNonPeakUpperBound() {
-        final DateTime userDateTime = new DateTime(2015, 1, 2, 20, 59, 59);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 2, 23, 0, 0).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalLong = uploadSettings.computeUploadIntervalForTests(userDateTime) == senseUploadConfiguration.getLongInterval();
+        final DateTime userDateTime = new DateTime(2015, 1, 2, 22, 59, 59);
+        final Boolean isUploadIntervalLong = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration) == senseUploadConfiguration.getLongInterval();
         assertThat(isUploadIntervalLong, is(true));
     }
 
     @Test
     public void testWeekdayPeakLowerBound() {
         final DateTime userDateTime = new DateTime(2015, 1, 1, 10, 0, 0);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 1, 12, 30, 0).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalShort = uploadSettings.computeUploadIntervalForTests(userDateTime) == senseUploadConfiguration.getShortInterval();
+        final Boolean isUploadIntervalShort = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration) == senseUploadConfiguration.getShortInterval();
         assertThat(isUploadIntervalShort, is(true));
     }
 
     @Test
     public void testWeekdayPeakUpperBound() {
         final DateTime userDateTime = new DateTime(2015, 1, 1, 10, 59, 59);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 1, 16, 0, 0).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalShort = uploadSettings.computeUploadIntervalForTests(userDateTime) == senseUploadConfiguration.getShortInterval();
+        final Boolean isUploadIntervalShort = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration) == senseUploadConfiguration.getShortInterval();
         assertThat(isUploadIntervalShort, is(true));
     }
 
     @Test
     public void testWeekendLowerBound() {
         final DateTime userDateTime = new DateTime(2015, 1, 3, 0, 0, 0);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 3, 5, 0, 0).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalShort = uploadSettings.computeUploadIntervalForTests(userDateTime) == senseUploadConfiguration.getShortInterval();
+        final Boolean isUploadIntervalShort = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration) == senseUploadConfiguration.getShortInterval();
         assertThat(isUploadIntervalShort, is(true));
     }
 
     @Test
     public void testWeekendUpperBound() {
         final DateTime userDateTime = new DateTime(2015, 1, 4, 23, 59, 59);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 2, 14, 0, 0).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalShort = uploadSettings.computeUploadIntervalForTests(userDateTime) == senseUploadConfiguration.getShortInterval();
+        final Boolean isUploadIntervalShort = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration) == senseUploadConfiguration.getShortInterval();
         assertThat(isUploadIntervalShort, is(true));
     }
 
     @Test
     public void testExpediteUploadInterval() {
         final DateTime userDateTime = new DateTime(2015, 1, 2, 12, 12, 12);
+        final Long simulateCurrentTimestamp = new DateTime(2015, 1, 2, 12, 11, 12).getMillis();
         final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 2, 12, 14, 12).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Integer unadjustedUploadInteval = uploadSettings.computeUploadIntervalForTests(userDateTime);
-        final Integer adjustedUploadInterval = uploadSettings.adjustUploadIntervalForTests(unadjustedUploadInteval, nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalOverwritten = adjustedUploadInterval == uploadSettings.getFastestUploadInterval();
+
+        final Integer unadjustedUploadInteval = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration);
+        final Integer adjustedUploadInterval = UploadSettings.adjustUploadIntervalInMinutes(simulateCurrentTimestamp, unadjustedUploadInteval, nextUserAlarmTimestamp);
+        final Boolean isUploadIntervalOverwritten = adjustedUploadInterval == UploadSettings.getFastestUploadInterval();
         assertThat(isUploadIntervalOverwritten, is(true));
     }
 
     @Test
     public void testRestoreStandardUploadInterval() {
         final DateTime userDateTime = new DateTime(2015, 1, 2, 12, 12, 12);
-        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 12, 13, 14, 12).getMillis();
-        final UploadSettings uploadSettings = new UploadSettings(DateTimeZone.getDefault(), nextUserAlarmTimestamp);
-        final Integer unadjustedUploadInterval = uploadSettings.computeUploadIntervalForTests(userDateTime);
-        final Integer adjustedUploadInterval = uploadSettings.adjustUploadIntervalForTests(unadjustedUploadInterval, nextUserAlarmTimestamp);
-        final Boolean isUploadIntervalOverwritten = adjustedUploadInterval == uploadSettings.getFastestUploadInterval();
+        final Long simulateCurrentTimestamp = new DateTime(2015, 1, 12, 12, 15, 12).getMillis();
+        final Long nextUserAlarmTimestamp = new DateTime(2015, 1, 12, 14, 14, 12).getMillis();
+
+        final Integer unadjustedUploadInterval = UploadSettings.computeUploadIntervalPerUserPerSetting(userDateTime, senseUploadConfiguration);
+        final Integer adjustedUploadInterval = UploadSettings.adjustUploadIntervalInMinutes(simulateCurrentTimestamp, unadjustedUploadInterval, nextUserAlarmTimestamp);
+        final Boolean isUploadIntervalOverwritten = adjustedUploadInterval == UploadSettings.getFastestUploadInterval();
         assertThat(isUploadIntervalOverwritten, is(false));
     }
-    */
 }


### PR DESCRIPTION
- Use static methods in UploadSettings instead of instance methods
- Adjust default non peak hour upper bound to 22
- Refactor unit tests
- Replace https://github.com/hello/suripu/pull/353, handled conflicts with https://github.com/hello/suripu/pull/355
  @pangw , @pims 
