### PR TITLE
Remove batch check

### DIFF
--- a/suripu-service/src/main/java/com/hello/suripu/service/resources/ReceiveResource.java
+++ b/suripu-service/src/main/java/com/hello/suripu/service/resources/ReceiveResource.java
@@ -533,8 +533,6 @@ public class ReceiveResource extends BaseResource {
             boolean canOTA = false;
             if(batch.hasUptimeInSecond()){
                 canOTA = (batch.getUptimeInSecond() > 20 * DateTimeConstants.SECONDS_PER_MINUTE);
-            }else{
-                canOTA = (batch.getDataList().size() > 1);
             }
 
             if(groups.contains("chris-dev") || groups.contains("video-photoshoot")){


### PR DESCRIPTION
@pims If the user's onboarding lasts for more than 1minute he will get OTA right after wifi connected because the 1st data will get upload immediately. We need to nitify all first 13 deta testers, I guess most of them has this issues because they are in ringtone-downloads group.
