### PR TITLE
Enlarge the upper bound for timeline triggering/disabling

### DIFF
--- a/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineWorkerConfiguration.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineWorkerConfiguration.java
@@ -136,7 +136,7 @@ public class TimelineWorkerConfiguration extends WorkerConfiguration {
     @Valid
     @NotNull
     @Min(5)
-    @Max(12)
+    @Max(24)
     @JsonProperty("hour_of_day_trigger")
     private Integer earliestProcessTime;
     public Integer getEarliestProcessTime(){
@@ -146,7 +146,7 @@ public class TimelineWorkerConfiguration extends WorkerConfiguration {
     @Valid
     @NotNull
     @Min(10)
-    @Max(12)
+    @Max(24)
     @JsonProperty("end_process_time")
     private Integer lastProcessTime;
     public Integer getLastProcessTime(){


### PR DESCRIPTION
@pims This is just a workaround. Even we replay the queue, the result it generated is not going to be the same because the worker relies on current time (more precisely, the current time in the user's timezone) to determine which day's timeline to process (And whether it should process). But it does provide a way to reprocess something.
