### PR TITLE
Still return the key-store hint when there's no metadata

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/KeyStoreDynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/KeyStoreDynamoDB.java
@@ -185,9 +185,11 @@ public class KeyStoreDynamoDB implements KeyStore {
         }
 
         final String aesKey = getItemResult.getItem().get(AES_KEY_ATTRIBUTE_NAME).getS();
-        final String metadata = getItemResult.getItem().get(METADATA).getS();
 
-        return Optional.of(new DeviceKeyStoreRecord(censorKey(aesKey), metadata));
+        if (!getItemResult.getItem().containsKey(METADATA)) {
+            return Optional.of(new DeviceKeyStoreRecord(censorKey(aesKey), "n/a"));
+        }
+        return Optional.of(new DeviceKeyStoreRecord(censorKey(aesKey), getItemResult.getItem().get(METADATA).getS()));
     }
 
     private String censorKey(final String key) {


### PR DESCRIPTION
@pims: to fix https://hello-admin.appspot.com/key_store/?device=D7979686FCD3EA1C&type=pill for Caroline's pill
