### PR TITLE
Not allow client set repeated alarm with no repeated days

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Alarm.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Alarm.java
@@ -295,8 +295,8 @@ public class Alarm {
             OK,
             NOT_VALID_NON_REPEATED_ALARM,
             SMART_ALARM_ALREADY_SET,
-            DUPLICATE_DAYS
-
+            DUPLICATE_DAYS,
+            REPEAT_DAYS_NOT_SET
 
         }
         /**
@@ -325,6 +325,10 @@ public class Alarm {
                         alarmDays.add(expectedRingTime.getDayOfWeek());
                     }
                 }else{
+                    if(alarm.dayOfWeek.isEmpty()){
+                        return AlarmStatus.REPEAT_DAYS_NOT_SET;
+                    }
+
                     if(!alarm.isSmart) {
                         continue;
                     }


### PR DESCRIPTION
@kattrali @decarbonization @longd3  One more error message when setting alarms: REPEAT_DAYS_NOT_SET if you set a repeated alarm with empty days of week. Clients might needs to update
