### PR TITLE
Assume awake instead of deep sleep for in_bed event

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Events/InBedEvent.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Events/InBedEvent.java
@@ -33,6 +33,6 @@ public class InBedEvent extends Event {
 
     @Override
     public int getSleepDepth() {
-        return 100;
+        return 0;
     }
 }


### PR DESCRIPTION
Currently, the `IN_BED` event has a sleep depth of `100`, indicating deep sleep. It seems to make more sense to assume the user is awake rather than deeply asleep when they get into bed. However, I'm not sure if this has some other computation implications for sound sleep or light sleep, etc.
![app screenshot](https://cloud.githubusercontent.com/assets/333454/6093355/d292510e-aeb5-11e4-9456-e845e07185c8.png)
