### PR TITLE
Don't show toss and turns if missed one bound of sleep events

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -319,9 +319,7 @@ public class TimelineProcessor {
         final List<Event> eventsWithSleepEvents = TimelineRefactored.mergeEvents(timEvents);
         final List<Event> smoothedEvents = TimelineUtils.smoothEvents(eventsWithSleepEvents);
 
-        final List<Event> cleanedUpEvents = TimelineUtils.removeMotionEventsOutsideBedPeriod(smoothedEvents,
-                                                            sleepEventsFromAlgorithm.get(0),
-                                                            sleepEventsFromAlgorithm.get(3));
+        final List<Event> cleanedUpEvents = TimelineUtils.removeMotionEventsOutsideBedPeriod(smoothedEvents, sleepEventsFromAlgorithm);
 
         final List<Event> greyEvents = TimelineUtils.greyNullEventsOutsideBedPeriod(cleanedUpEvents,
                 sleepEventsFromAlgorithm.get(0),
@@ -504,9 +502,7 @@ public class TimelineProcessor {
         final List<Event> eventsWithSleepEvents = TimelineRefactored.mergeEvents(timelineEvents);
         final List<Event> smoothedEvents = TimelineUtils.smoothEvents(eventsWithSleepEvents);
 
-        final List<Event> cleanedUpEvents = TimelineUtils.removeMotionEventsOutsideBedPeriod(smoothedEvents,
-                sleepEventsFromAlgorithm.get(0),
-                sleepEventsFromAlgorithm.get(3));
+        final List<Event> cleanedUpEvents = TimelineUtils.removeMotionEventsOutsideBedPeriod(smoothedEvents, sleepEventsFromAlgorithm);
 
         final List<Event> greyEvents = TimelineUtils.greyNullEventsOutsideBedPeriod(cleanedUpEvents,
                 sleepEventsFromAlgorithm.get(0),


### PR DESCRIPTION
@pims This will dismiss all toss and turns if one bound (inbed-sleep/awake-outbed) of sleep events are dismissed by safeguard. However, i am not sure this is what we want. We might want to discuss with the design team on whether to merge this.
