### PR TITLE
Return null instead of Jan 1st 1970

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/DeviceResources.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/DeviceResources.java
@@ -29,7 +29,6 @@ import com.hello.suripu.core.oauth.OAuthScope;
 import com.hello.suripu.core.oauth.Scope;
 import com.hello.suripu.core.util.JsonError;
 import com.yammer.metrics.annotation.Timed;
-import org.joda.time.DateTime;
 import org.skife.jdbi.v2.Transaction;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
 import org.skife.jdbi.v2.TransactionStatus;
@@ -314,7 +313,7 @@ public class DeviceResources {
             if(senseStatusOptional.isPresent()) {
                 devices.add(new Device(Device.Type.SENSE, sense.externalDeviceId, Device.State.NORMAL, senseStatusOptional.get().firmwareVersion, senseStatusOptional.get().lastSeen));
             } else {
-                devices.add(new Device(Device.Type.SENSE, sense.externalDeviceId, Device.State.UNKNOWN, "-", new DateTime(1970,1,1, 0,0,0)));
+                devices.add(new Device(Device.Type.SENSE, sense.externalDeviceId, Device.State.UNKNOWN, "-", null));
             }
         }
 


### PR DESCRIPTION
@decarbonization would this be a breaking change for you?

In case the device hasn't uploaded any data after onboarding, the API would no longer return 1970 Jan 1st (0 timestamp) but a `null` value.
