### PR TITLE
Changing S3 cache eviction policy to evict after write instead of access.

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/firmware/FirmwareUpdateStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/firmware/FirmwareUpdateStore.java
@@ -74,7 +74,7 @@ public class FirmwareUpdateStore {
                                              final AmazonS3 s3Signer,
                                              final Integer s3CacheExpireMinutes) {
         final Cache<String, Pair<Integer, List<OutputProtos.SyncResponse.FileDownload>>> s3Cache = CacheBuilder.newBuilder()
-                .expireAfterAccess(s3CacheExpireMinutes, TimeUnit.MINUTES)
+                .expireAfterWrite(s3CacheExpireMinutes, TimeUnit.MINUTES)
                 .build();
         return new FirmwareUpdateStore(firmwareUpdateDAOImpl, s3, bucketName, s3Signer, s3Cache);
     }


### PR DESCRIPTION
Making this change makes the cache evict items after a fixed amount of time after write instead of the current method of evicting after a period of inactivity. 
