### PR TITLE
Fix for FirmwareUpdateStore returning multiple file listings bug

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/firmware/FirmwareUpdateStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/firmware/FirmwareUpdateStore.java
@@ -144,7 +144,7 @@ public class FirmwareUpdateStore {
 
         final ListObjectsRequest listObjectsRequest = new ListObjectsRequest();
         listObjectsRequest.withBucketName(bucketName);
-        listObjectsRequest.withPrefix("sense/" + group);
+        listObjectsRequest.withPrefix("sense/" + group + "/");
 
         final ObjectListing objectListing = s3.listObjects(listObjectsRequest);
         final List<String> files = new ArrayList<>();


### PR DESCRIPTION
The listObjects request was returning multiple results (s3://hello-firmware/sense/release*). This could cause a top.bin from one version of the fw and kitsune.bin from another to be downloaded to sense. This bug prevents OTA of the 'release' branch. 

Terminating the path properly corrects this issue. 

```
https://hello-firmware.s3.amazonaws.com/sense/release/top.bin?AWSAccessKeyId=AKIAJVQV7XJU23UWILSQ&Expires=1426486246&Signature=rnmv3pLok%2Bg1LIFYV0eJ4Y0HUOU%3D
{'content-length': '58272', 'x-amz-id-2': '4pbLFb7w7w9l8/EV2Rh0YXlPpT3HyHtJeicnghRqOnJd/+gWbQnwFnNcb3ENKrCv', 'accept-ranges': 'bytes', 'server': 'AmazonS3', 'last-modified': 'Thu, 29 Jan 2015 06:51:25 GMT', 'x-amz-request-id': 'D863923FD0E00FFA', 'etag': '"6f2738e1272d3987789886145094daa5"', 'date': 'Mon, 16 Mar 2015 05:10:50 GMT', 'content-type': 'application/octet-stream'}
200
h ca22be90245359ae9b6c7c6a73ce9a06e1a91ef3
hello-firmware.s3.amazonaws.com /sense/release/kitsune.bin?AWSAccessKeyId=AKIAJVQV7XJU23UWILSQ&Expires=1426486246&Signature=DbzLG1FTU7Y7yl1GUAaESPZUO%2FI%3D [Decode error - output not utf-8]
https://hello-firmware.s3.amazonaws.com/sense/release/kitsune.bin?AWSAccessKeyId=AKIAJVQV7XJU23UWILSQ&Expires=1426486246&Signature=DbzLG1FTU7Y7yl1GUAaESPZUO%2FI%3D
{'content-length': '133648', 'x-amz-id-2': 'ZRJSyjgqs1eZs7mANxYQjVDsxbxq/So/3evB1yQwVK1LynCOmY0jJE9smXr8j7tI', 'accept-ranges': 'bytes', 'server': 'AmazonS3', 'last-modified': 'Fri, 13 Mar 2015 20:45:53 GMT', 'x-amz-request-id': '3200074D718DB4F0', 'etag': '"de8ca326010ea9f7bc56c21a07375174"', 'date': 'Mon, 16 Mar 2015 05:10:50 GMT', 'content-type': 'application/x-mac'}
200
h 03c7e33f82f75a666de513bc1ab4d6cc7c922845
[Decode error - output not utf-8]
https://hello-firmware.s3.amazonaws.com/sense/release_post_cny/kitsune.bin?AWSAccessKeyId=AKIAJVQV7XJU23UWILSQ&Expires=1426486246&Signature=Kiflf1iBGFCfTMlO%2FA71beD6dqM%3D
{'content-length': '136000', 'x-amz-id-2': 'Er5wDulGZX11PrLqpS9LG+s3JJjp/d21eb8ssGBZhkCS/pD58phrCv/r+mnyNiv5', 'accept-ranges': 'bytes', 'server': 'AmazonS3', 'last-modified': 'Sun, 01 Mar 2015 01:16:22 GMT', 'x-amz-request-id': '32A4064D8F0B3104', 'etag': '"ea4559d76854645b78be6e7d572234e2"', 'date': 'Mon, 16 Mar 2015 05:10:51 GMT', 'content-type': 'application/x-mac'}
200
h c8eae9f14979c13852b641ec51cd0e2300dbb66f
[Decode error - output not utf-8]
https://hello-firmware.s3.amazonaws.com/sense/release_with_servers/kitsune.bin?AWSAccessKeyId=AKIAJVQV7XJU23UWILSQ&Expires=1426486246&Signature=OeDC4kq1ff0PjQovpc4e1Ns%2Fre0%3D
{'content-length': '138968', 'x-amz-id-2': 'aNVyo3nsQB818UvQECfUh5+guD2hUAsHaXLqJIRKXb8aQfnbSb5YYVl0rhKScgZj', 'accept-ranges': 'bytes', 'server': 'AmazonS3', 'last-modified': 'Fri, 20 Feb 2015 17:46:14 GMT', 'x-amz-request-id': 'CCA929B8E433F6AE', 'etag': '"98d50834f202a26e1df94afb2edb906d"', 'date': 'Mon, 16 Mar 2015 05:10:52 GMT', 'content-type': 'application/x-mac'}
200
```
