### PR TITLE
"Office Only" OTA checks override and IP restriction feature

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -20,6 +20,5 @@ public class FeatureFlipper {
     public final static String IN_OUT_BED_EVENTS = "in_out_bed_events";
     public final static String HMM_ALGORITHM = "hmm_algorithm";
     public final static String PARTNER_FILTER = "partner_filter";
-
-
+    public final static String OFFICE_ONLY_OVERRIDE = "office_only_override";
 }


### PR DESCRIPTION
This adds a feature that allows us to simultaneously restrict updates to our office only AND bypass all other OTA checks for select devices. This is meant for use in resolving the device ID = 00000... issue.

Testing can proceed by adding DevID '000...'  as the device ID to the feature configuration for 'office_only_override'. Then, adding DevID '000...' to a group for the test OTA will allow devices originating from our office IP to update to this test group's fw version. 

Once tested, we simply deactivate the 'office_only_override' feature, leave the group in place for public devices with '0000' ID and allow them to OTA as normal. If need be, we can flip the 'always_ota" feature for them and speed up the process. 

@pims This needs review, please. 
