### PR TITLE
Multiple adjustments to OTA config values

### DIFF
--- a/suripu-service/suripu-service.dev.yml.example
+++ b/suripu-service/suripu-service.dev.yml.example
@@ -158,10 +158,10 @@ sense_upload_configuration:
   
 ota_configuration:
   start_update_window_hour: 11
-  end_update_window_hour: 22
-  device_uptime_delay: 20
+  end_update_window_hour: 20
+  device_uptime_delay: 60
   always_ota_groups: [chris-dev, video-photoshoot, victor]
-  s3cache_expire_minutes: 60
+  s3cache_expire_minutes: 20
 
 kinesis_logger:
   stream_name: logs

--- a/suripu-service/suripu-service.prod.yml
+++ b/suripu-service/suripu-service.prod.yml
@@ -145,10 +145,10 @@ sense_upload_configuration:
   
 ota_configuration:
   start_update_window_hour: 11
-  end_update_window_hour: 22
-  device_uptime_delay: 20
+  end_update_window_hour: 20
+  device_uptime_delay: 60
   always_ota_groups: [chris-dev, video-photoshoot, victor]
-  s3cache_expire_minutes: 60
+  s3cache_expire_minutes: 20
 
 kinesis_logger:
   stream_name: logs

--- a/suripu-service/suripu-service.staging.yml
+++ b/suripu-service/suripu-service.staging.yml
@@ -145,10 +145,10 @@ sense_upload_configuration:
 
 ota_configuration:
   start_update_window_hour: 11
-  end_update_window_hour: 22
-  device_uptime_delay: 20
+  end_update_window_hour: 20
+  device_uptime_delay: 60
   always_ota_groups: [chris-dev, video-photoshoot, victor]
-  s3cache_expire_minutes: 60
+  s3cache_expire_minutes: 20
   
 kinesis_logger:
   stream_name: logs


### PR DESCRIPTION
Increasing the uptime delay check time to 60 mins. (requested by Kevin & Chris to further avoid OTA during onboarding)
Reducing the S3 Cache expiration time to 20 mins. (to evict old URLs sooner)
Reducing the update window end time to 8PM. (to not disrupt early sleepers)
