### PR TITLE
Fix bug where time series options would come back in different order

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/TrendGraph.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/TrendGraph.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.hello.suripu.core.translations.English;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +15,7 @@ import java.util.Map;
 public class TrendGraph {
     public final static Map<TimePeriodType, Integer> PERIOD_TYPE_DAYS;
     static {
-       final Map<TimePeriodType, Integer> tmpMap = new HashMap<>();
+       final Map<TimePeriodType, Integer> tmpMap = new LinkedHashMap<>();
         tmpMap.put(TimePeriodType.OVER_TIME_1W, 7);
         tmpMap.put(TimePeriodType.OVER_TIME_2W, 14);
         tmpMap.put(TimePeriodType.OVER_TIME_1M, 30);

--- a/suripu-core/src/test/java/com/hello/suripu/core/models/TrendGraphTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/models/TrendGraphTest.java
@@ -1,0 +1,34 @@
+package com.hello.suripu.core.models;
+
+import com.hello.suripu.core.models.Insights.TrendGraph;
+import org.junit.Test;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Created by jimmy on 4/2/15.
+ */
+public class TrendGraphTest {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(TrendGraphTest.class);
+
+    @Test
+    public void testGetTimeSeriesOptions() {
+        LOGGER.debug("getTimeSeriesOptions should return incrementally larger options");
+        final List<String> options = TrendGraph.TimePeriodType.getTimeSeriesOptions(90);
+        int previousTime = 0;
+        for (final String option : options) {
+            final TrendGraph.TimePeriodType type = TrendGraph.TimePeriodType.fromString(option);
+            final int time = TrendGraph.PERIOD_TYPE_DAYS.get(type);
+            Assert.assertTrue(previousTime < time);
+            previousTime = time;
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes:
1. https://github.com/hello/bugs/issues/138
2. https://github.com/hello/bugs/issues/51

By using an ordered map rather than a hashmap
