### PR TITLE
Fix the get first wave port from python

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/TimelineUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/TimelineUtils.java
@@ -939,7 +939,7 @@ public class TimelineUtils {
 
         final long startDetectionTimestampMillis = (lastMotionTimestampMillis - firstMotionTimestampMillis) / 2 + firstMotionTimestampMillis;
         for(final Sample wave:waveData){
-            if(wave.dateTime >= startDetectionTimestampMillis && wave.dateTime <= lastMotionTimestampMillis){
+            if(wave.value > 0 && wave.dateTime >= startDetectionTimestampMillis && wave.dateTime <= lastMotionTimestampMillis){
                 return Optional.of(new DateTime(wave.dateTime, DateTimeZone.forOffsetMillis(wave.offsetMillis)));
             }
         }


### PR DESCRIPTION
The first wave is wave count > 0. @pims small fix tested on research (took me 3 weeks to figure this thing out)
