### PR TITLE
Update JodaTime module to 2.7 and exclude JodaTime from other dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <dropwizard.version>0.6.2</dropwizard.version>
         <protobuf.version>2.5.0</protobuf.version>
         <aws.sdk.version>1.9.13</aws.sdk.version>
+        <jodatime.version>2.7</jodatime.version>
         <librato.reporter.version>2.2.0.5</librato.reporter.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -61,6 +62,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${jodatime.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.hello.dropwizard</groupId>
                 <artifactId>dropwizard-mikkusu</artifactId>
                 <version>0.0.1</version>
@@ -69,6 +75,12 @@
                 <groupId>com.yammer.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>
                 <version>${dropwizard.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>joda-time</artifactId>
+                        <groupId>joda-time</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.yammer.dropwizard</groupId>

--- a/suripu-admin/pom.xml
+++ b/suripu-admin/pom.xml
@@ -14,6 +14,12 @@
             <groupId>com.yammer.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.hello.suripu</groupId>

--- a/suripu-admin/src/test/java/JodaTimeTest.java
+++ b/suripu-admin/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}

--- a/suripu-algorithm/pom.xml
+++ b/suripu-algorithm/pom.xml
@@ -11,9 +11,20 @@
 
     <dependencies>
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${jodatime.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.yammer.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/suripu-algorithm/src/test/java/JodaTimeTest.java
+++ b/suripu-algorithm/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}

--- a/suripu-app/src/test/java/JodaTimeTest.java
+++ b/suripu-app/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}

--- a/suripu-core/pom.xml
+++ b/suripu-core/pom.xml
@@ -40,6 +40,12 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.hello.suripu</groupId>

--- a/suripu-core/src/test/java/JodaTimeTest.java
+++ b/suripu-core/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}

--- a/suripu-factory/pom.xml
+++ b/suripu-factory/pom.xml
@@ -29,6 +29,12 @@
             <groupId>com.yammer.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/suripu-research/src/test/java/JodaTimeTest.java
+++ b/suripu-research/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}

--- a/suripu-service/src/test/java/JodaTimeTest.java
+++ b/suripu-service/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}

--- a/suripu-workers/pom.xml
+++ b/suripu-workers/pom.xml
@@ -29,11 +29,23 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
             <version>1.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.roaringbitmap</groupId>
@@ -55,6 +67,12 @@
             <groupId>com.yammer.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>joda-time</artifactId>
+                    <groupId>joda-time</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.yammer.dropwizard</groupId>

--- a/suripu-workers/src/test/java/JodaTimeTest.java
+++ b/suripu-workers/src/test/java/JodaTimeTest.java
@@ -1,0 +1,18 @@
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by pangwu on 4/10/15.
+ */
+public class JodaTimeTest {
+    @Test
+    public void testUsingTheRightJodaTime(){
+        final DateTime dateTimeFromYmd = new DateTime(2015, 4, 11, 10, 30, 0, 0, DateTimeZone.forID("Europe/Moscow"));
+        final DateTime dateTimeFromMillis = new DateTime(1428733800000L, DateTimeZone.forID("Europe/Moscow"));
+        assertThat(dateTimeFromYmd.equals(dateTimeFromMillis), is(false));
+    }
+}


### PR DESCRIPTION
1) Update JodaTime module to 2.7 and exclude JodaTime from other dependencies.
2) Verification tests on all modules make sure they all use the new Joda time.
