### PR TITLE
feedback to affect additional wakes/sleeps

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -237,7 +237,7 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
 
         //  get the feedback in one form or another
         final ImmutableList<TimelineFeedback> feedbackList = getFeedbackList(accountId, targetDate, offsetMillis);
-        final Map<Event.Type, Event> feedbackEvents = FeedbackUtils.convertFeedbackToDateTime(feedbackList, offsetMillis);
+        final Map<Event.Type, Event> feedbackEvents = FeedbackUtils.getFeedbackAsEventMap(feedbackList, offsetMillis);
 
         for(final Event event : feedbackEvents.values()) {
             LOGGER.info("Overriding {} with {} for account {}", event.getType().name(), event, accountId);

--- a/suripu-core/src/main/java/com/hello/suripu/core/util/FeedbackUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/FeedbackUtils.java
@@ -117,7 +117,7 @@ public class FeedbackUtils {
     }
 
     /* returns map of events by event type */
-    public static Map<Event.Type, Event> convertFeedbackToDateTime(final List<TimelineFeedback> timelineFeedbackList, final Integer offsetMillis) {
+    public static Map<Event.Type, Event> getFeedbackAsEventMap(final List<TimelineFeedback> timelineFeedbackList, final Integer offsetMillis) {
         final Map<Event.Type, Event> events = Maps.newHashMap();
 
         /* iterate through list*/

--- a/suripu-core/src/test/java/com/hello/suripu/core/util/FeedbackUtilsTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/FeedbackUtilsTest.java
@@ -2,9 +2,14 @@ package com.hello.suripu.core.util;
 
 import com.google.common.base.Optional;
 import com.hello.suripu.core.models.Event;
+import com.hello.suripu.core.models.SleepSegment;
 import com.hello.suripu.core.models.TimelineFeedback;
+import junit.framework.TestCase;
 import org.joda.time.DateTime;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -13,9 +18,45 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class FeedbackUtilsTest {
 
     @Test
+    public void TestFeedbackReprocessing() {
+
+        final List<Event> events = new ArrayList<>();
+
+        final long t1 = 1429134060000L; //Wed, 15 Apr 2015 21:41:00 GMT
+        final long t2 = t1 + 60000L;
+        final int offset = 3600000; // + 1 hour
+        final long expectedTime = t1 + 4 * 60000L;
+
+
+        events.add(Event.createFromType(Event.Type.SLEEP,t1,t2,offset,Optional.of("FOOBARS"),Optional.<SleepSegment.SoundInfo>absent(),Optional.<Integer>absent()));
+
+        /*
+
+            @JsonProperty("date_of_night") final String dateOfNight,
+            @JsonProperty("old_time_of_event") final String oldTimeOfEvent,
+            @JsonProperty("new_time_of_event") final String newTimeOfEvent,
+            @JsonProperty("event_type") final String eventTypeString) {
+
+
+         */
+        final TimelineFeedback feedback = TimelineFeedback.create("2015-04-15","22:41","22:45","SLEEP");
+
+        final List<TimelineFeedback> timelineFeedbacks = new ArrayList<>();
+        timelineFeedbacks.add(feedback);
+
+        final  List<Event>  newEvents = FeedbackUtils.reprocessExtraEventsBasedOnFeedback(timelineFeedbacks,events,offset);
+
+
+        final long mysleeptime = newEvents.get(0).getStartTimestamp();
+
+        TestCase.assertEquals(expectedTime, mysleeptime);
+
+    }
+
+    @Test
     public void testConvertFeedbackToDateTimeWakeup() {
         final TimelineFeedback feedback = TimelineFeedback.create("2015-02-03", "07:00", "7:15", Event.Type.WAKE_UP.name());
-        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTime(feedback, 0);
+        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTimeByNewTime(feedback, 0);
         assertThat(optional.isPresent(), is(true));
         final DateTime dt = optional.get();
         assertThat(dt.getDayOfMonth(), equalTo(4));
@@ -24,7 +65,7 @@ public class FeedbackUtilsTest {
 
 
         final TimelineFeedback secondFeedback = TimelineFeedback.create("2015-02-03", "07:00", "14:15", Event.Type.WAKE_UP.name());
-        final Optional<DateTime> secondOptional = FeedbackUtils.convertFeedbackToDateTime(secondFeedback,0);
+        final Optional<DateTime> secondOptional = FeedbackUtils.convertFeedbackToDateTimeByNewTime(secondFeedback, 0);
         assertThat(secondOptional.isPresent(), is(true));
         final DateTime secondDt = secondOptional.get();
         assertThat(secondDt.getDayOfMonth(), equalTo(4));
@@ -35,7 +76,7 @@ public class FeedbackUtilsTest {
     @Test
     public void testConvertFeedbackToDateTimeInvalidWakeUp() {
         final TimelineFeedback feedback = TimelineFeedback.create("2015-02-03", "07:00", "23:15", Event.Type.WAKE_UP.name());
-        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTime(feedback,0);
+        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTimeByNewTime(feedback, 0);
         assertThat(optional.isPresent(), is(false));
     }
 
@@ -44,7 +85,7 @@ public class FeedbackUtilsTest {
     @Test
     public void testConvertFeedbackToDateTimeFallasleep() {
         final TimelineFeedback feedback = TimelineFeedback.create("2015-02-03", "23:00", "00:15", Event.Type.SLEEP.name());
-        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTime(feedback,0);
+        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTimeByNewTime(feedback, 0);
         assertThat(optional.isPresent(), is(true));
         final DateTime dt = optional.get();
         assertThat(dt.getDayOfMonth(), equalTo(4));
@@ -53,7 +94,7 @@ public class FeedbackUtilsTest {
 
 
         final TimelineFeedback secondFeedback = TimelineFeedback.create("2015-02-03", "00:15", "23:15", Event.Type.SLEEP.name());
-        final Optional<DateTime> secondOptional = FeedbackUtils.convertFeedbackToDateTime(secondFeedback,0);
+        final Optional<DateTime> secondOptional = FeedbackUtils.convertFeedbackToDateTimeByNewTime(secondFeedback, 0);
         assertThat(secondOptional.isPresent(), is(true));
         final DateTime secondDt = secondOptional.get();
         assertThat(secondDt.getDayOfMonth(), equalTo(3));
@@ -64,7 +105,7 @@ public class FeedbackUtilsTest {
     @Test
     public void testConvertFeedbackToDateTimeInvalidFallAsleep() {
         final TimelineFeedback feedback = TimelineFeedback.create("2015-02-03", "23:00", "16:00", Event.Type.SLEEP.name());
-        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTime(feedback,0);
+        final Optional<DateTime> optional = FeedbackUtils.convertFeedbackToDateTimeByNewTime(feedback, 0);
         assertThat(optional.isPresent(), is(false));
     }
 }


### PR DESCRIPTION
Behavior: If feedback original time and event type matches an "extra" event, then the feedback event replaces the extra event at its new time.
