### PR TITLE
fix unit test compilation

### DIFF
--- a/suripu-core/src/test/java/com/hello/suripu/core/util/TimelineUtilsTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/TimelineUtilsTest.java
@@ -883,16 +883,14 @@ public class TimelineUtilsTest extends FixtureTest {
         final List<TrackerMotion> trackerMotions = loadTrackerMotionFromCSV("fixtures/algorithm/qf_motion_2015_03_12_raw.csv");
         final List<DateTime> lightOuts = new ArrayList<>();
         lightOuts.add(new DateTime(1426218480000L, DateTimeZone.forOffsetMillis(trackerMotions.get(0).offsetMillis)));
-        
 
-        Optional<VotingSleepEvents> votingSleepEventsOptional = TimelineUtils.getSleepEventsFromVoting(trackerMotions,
+
+        final Optional<VotingSleepEvents> votingSleepEventsOptional = TimelineUtils.getSleepEventsFromVoting(trackerMotions,
                 Collections.EMPTY_LIST,
                 lightOuts,
                 Optional.<DateTime>absent());
 
-        if (!votingSleepEventsOptional.isPresent()) {
-            return;
-        }
+        assertThat(votingSleepEventsOptional.isPresent(),is(true));
 
         final SleepEvents<Optional<Event>> sleepEventObj = votingSleepEventsOptional.get().sleepEvents;
 


### PR DESCRIPTION
I have reason to believe that JDK 1.8 behaves differently for some reason than 1.7, and this causes the unit test "testGetResultVotingAlgorithm" to fail compilation, probably.  Pang + Kingshy are on 1.7, I'm on 1.8.  It works for them, but not for me.

Refactoring the test a tiny little bit causes it to compile now.
