### PR TITLE
log timeline session -- IN PROGRESS

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/SuripuApp.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/SuripuApp.java
@@ -315,25 +315,26 @@ public class SuripuApp extends Service<SuripuAppConfiguration> {
                 120 // 2 minutes for cache
         );
 
-        environment.addResource(new OAuthResource(accessTokenStore, applicationStore, accountDAO, notificationSubscriptionDAOWrapper));
-        environment.addResource(new AccountResource(accountDAO));
-        environment.addProvider(new RoomConditionsResource(accountDAO, deviceDataDAO, deviceDAO, configuration.getAllowedQueryRange()));
-        environment.addResource(new DeviceResources(deviceDAO, deviceDataDAO, trackerMotionDAO, mergedUserInfoDynamoDB, pillHeartBeatDAO));
-        final KeyStoreUtils keyStoreUtils = KeyStoreUtils.build(amazonS3, "hello-secure","hello-pvt.pem");
-        environment.addResource(new ProvisionResource(senseKeyStore, pillKeyStore, keyStoreUtils, pillProvisionDAO, amazonS3));
 
-        final TimelineProcessor timelineProcessor = new TimelineProcessor(
+        final TimelineResource.DAOs timeineResourceDAOs = new TimelineResource.DAOs(
+                accountDAO,
+                timelineDAODynamoDB,
+                timelineLogDAO,
                 trackerMotionDAO,
                 deviceDAO,
                 deviceDataDAO,
                 ringTimeHistoryDAODynamoDB,
                 feedbackDAO,
                 sleepHmmDAODynamoDB,
-                accountDAO,
                 sleepStatsDAODynamoDB);
 
-        environment.addResource(new TimelineResource(accountDAO, timelineDAODynamoDB,timelineLogDAO, timelineProcessor));
-
+        environment.addResource(new OAuthResource(accessTokenStore, applicationStore, accountDAO, notificationSubscriptionDAOWrapper));
+        environment.addResource(new AccountResource(accountDAO));
+        environment.addProvider(new RoomConditionsResource(accountDAO, deviceDataDAO, deviceDAO, configuration.getAllowedQueryRange()));
+        environment.addResource(new DeviceResources(deviceDAO, deviceDataDAO, trackerMotionDAO, mergedUserInfoDynamoDB, pillHeartBeatDAO));
+        final KeyStoreUtils keyStoreUtils = KeyStoreUtils.build(amazonS3, "hello-secure","hello-pvt.pem");
+        environment.addResource(new ProvisionResource(senseKeyStore, pillKeyStore, keyStoreUtils, pillProvisionDAO, amazonS3));
+        environment.addResource(new TimelineResource(timeineResourceDAOs));
         environment.addResource(new TimeZoneResource(timeZoneHistoryDAODynamoDB, mergedUserInfoDynamoDB, deviceDAO));
         environment.addResource(new AlarmResource(alarmDAODynamoDB, mergedUserInfoDynamoDB, deviceDAO, amazonS3));
 

--- a/suripu-app/src/main/java/com/hello/suripu/app/cli/PopulateSleepScoreTable.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/cli/PopulateSleepScoreTable.java
@@ -20,6 +20,7 @@ import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
 import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.util.JodaArgumentFactory;
 import com.hello.suripu.core.db.util.PostgresIntegerArrayArgumentFactory;
+import com.hello.suripu.core.logging.LoggerWithSessionId;
 import com.hello.suripu.core.models.DeviceAccountPair;
 import com.hello.suripu.core.models.Timeline;
 import com.hello.suripu.core.models.TimelineResult;
@@ -105,13 +106,16 @@ public class PopulateSleepScoreTable extends ConfiguredCommand<SuripuAppConfigur
         final RolloutAppModule module = new RolloutAppModule(featureStore, 30);
         ObjectGraphRoot.getInstance().init(module);
 
+        final Logger logger = new LoggerWithSessionId(LOGGER,"PopulateSleepScoreTable");
+
         final TimelineProcessor timelineProcessor = new TimelineProcessor(trackerMotionDAO,
                 deviceDAO, deviceDataDAO,
                 ringTimeHistoryDAODynamoDB,
                 feedbackDAO,
                 sleepHmmDAODynamoDB,
                 accountDAO,
-                sleepStatsDAODynamoDB);
+                sleepStatsDAODynamoDB,
+                logger);
 
         LOGGER.info("Getting all pills..");
         final List<DeviceAccountPair> activePills = deviceDAO.getAllPills(true);

--- a/suripu-core/src/main/java/com/hello/suripu/core/logging/LoggerWithSessionId.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/logging/LoggerWithSessionId.java
@@ -17,7 +17,7 @@ public class LoggerWithSessionId implements Logger {
         //UID as token
         String uuidString=  UUID.randomUUID().toString();
 
-        if (!extraInfo.isEmpty()) {
+        if (extraInfo != null && !extraInfo.isEmpty()) {
             uuidString += " " + extraInfo;
         }
         return  uuidString;
@@ -28,7 +28,19 @@ public class LoggerWithSessionId implements Logger {
     }
 
     final public Logger logger;
-    public LoggerWithSessionId(Logger original,final String extraInfo) {
+
+    public LoggerWithSessionId(final Logger original,final String extraInfo,final boolean useSessionId) {
+        logger = original;
+
+        if (useSessionId) {
+            uniqeString = getToken(extraInfo);
+        }
+        else {
+            uniqeString = extraInfo;
+        }
+    }
+
+    public LoggerWithSessionId(final Logger original,final String extraInfo) {
         logger = original;
         uniqeString = getToken(extraInfo);
     }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -44,7 +44,6 @@ import com.hello.suripu.core.util.VotingSleepEvents;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,7 +56,7 @@ import java.util.Set;
 public class TimelineProcessor extends FeatureFlippedProcessor {
 
     public static final String VERSION = "0.0.2";
-    private static final Logger LOGGER = LoggerFactory.getLogger(TimelineProcessor.class);
+    private final Logger LOGGER;
     private static final Integer MIN_SLEEP_DURATION_FOR_SLEEP_SCORE_IN_MINUTES = 3 * 60;
     private final TrackerMotionDAO trackerMotionDAO;
     private final DeviceDAO deviceDAO;
@@ -82,7 +81,8 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
                             final FeedbackDAO feedbackDAO,
                             final SleepHmmDAO sleepHmmDAO,
                             final AccountDAO accountDAO,
-                            final SleepStatsDAODynamoDB sleepStatsDAODynamoDB) {
+                            final SleepStatsDAODynamoDB sleepStatsDAODynamoDB,
+                             final Logger logger) {
         this.trackerMotionDAO = trackerMotionDAO;
         this.deviceDAO = deviceDAO;
         this.deviceDataDAO = deviceDataDAO;
@@ -91,6 +91,7 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         this.sleepHmmDAO = sleepHmmDAO;
         this.accountDAO = accountDAO;
         this.sleepStatsDAODynamoDB = sleepStatsDAODynamoDB;
+        this.LOGGER = logger;
     }
 
     public boolean shouldProcessTimelineByWorker(final long accountId,

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineWorkerCommand.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineWorkerCommand.java
@@ -29,6 +29,7 @@ import com.hello.suripu.core.db.TimelineDAODynamoDB;
 import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.util.JodaArgumentFactory;
 import com.hello.suripu.core.db.util.PostgresIntegerArrayArgumentFactory;
+import com.hello.suripu.core.logging.LoggerWithSessionId;
 import com.hello.suripu.core.processors.TimelineProcessor;
 import com.hello.suripu.workers.framework.WorkerEnvironmentCommand;
 import com.hello.suripu.workers.framework.WorkerRolloutModule;
@@ -129,13 +130,15 @@ public class TimelineWorkerCommand extends WorkerEnvironmentCommand<TimelineWork
         final WorkerRolloutModule workerRolloutModule = new WorkerRolloutModule(featureStore, 30);
         ObjectGraphRoot.getInstance().init(workerRolloutModule);
 
+
         final TimelineProcessor timelineProcessor = new TimelineProcessor(trackerMotionDAO,
                 deviceDAO, deviceDataDAO,
                 ringTimeHistoryDAODynamoDB,
                 feedbackDAO,
                 sleepHmmDAODynamoDB,
                 accountDAO,
-                sleepStatsDAODynamoDB);
+                sleepStatsDAODynamoDB,
+                LOGGER);
 
         final ImmutableMap<QueueName, String> queueNames = configuration.getQueues();
 


### PR DESCRIPTION
When you log in TimelineProcessor, it prepends a UUID so one can find log messages that came from the same session.  This let's you filter log messages from the server so you can actually trace what happened for a user.

-Added logger wrapper which prepends whatever you want, like a UUID
-Timeline processor is instantiated with logger given in constructor

Pros: this is awesome
Cons: since I'm wrapping the logger from TimelineResource, all the log messages will say they came from TimelineResource.

Alternative: use logger factory every time the user pulls the timeline.  

Is creating a logger object expensive?
