### PR TITLE
If HMM fails, TimelineProcessor will try the regular algorithm instead.

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -436,16 +436,23 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
 
 
             if (this.hasHmmEnabled(accountId)) {
-                /* DO HMM */
+
+                /* DO HMM, unless you get no result, then do the regular algorithm */
                 Optional<HmmAlgorithmResults> results = fromHmm(accountId, currentTime, targetDate, endDate, sensorData.trackerMotions, sensorData.allSensorSampleList);
 
-                if (!results.isPresent()) {
-                    return Optional.absent();
+                if (results.isPresent()) {
+                    LOGGER.debug("HMM Suceeded.");
+                    sleepEventsFromAlgorithmOptional = Optional.of(results.get().mainEvents);
+                    extraEvents = results.get().allTheOtherWakesAndSleeps;
+                    algorithm = ALGORITHM_NAME_HMM;
+                } else {
+                    LOGGER.debug("HMM Failed, trying regular algorithm instead");
+                    sleepEventsFromAlgorithmOptional = Optional.of(fromAlgorithm(targetDate,
+                            sensorData.trackerMotions,
+                            sensorData.allSensorSampleList.get(Sensor.LIGHT),
+                            sensorData.allSensorSampleList.get(Sensor.WAVE_COUNT)));
+                    algorithm = ALGORITHM_NAME_REGULAR;
                 }
-
-                sleepEventsFromAlgorithmOptional = Optional.of(results.get().mainEvents);
-                extraEvents = results.get().allTheOtherWakesAndSleeps;
-                algorithm = ALGORITHM_NAME_HMM;
 
             } else if(this.hasVotingEnabled(accountId)){
                 final Optional<VotingSleepEvents> votingSleepEventsOptional = fromVotingAlgorithm(sensorData.trackerMotions,


### PR DESCRIPTION
fixing the case where the HMM just doesn't work for some people because the model is just not right for them (i.e. sleep always in the light)
