### PR TITLE
feedback DAO returns account_id with feedback

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/FeedbackDAO.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/FeedbackDAO.java
@@ -61,8 +61,11 @@ public abstract class FeedbackDAO {
 
     }
 
-    @SqlQuery("SELECT * FROM timeline_feedback where account_id = :account_id AND date_of_night = :date_of_night order by created")
+    @SqlQuery("SELECT * FROM timeline_feedback WHERE account_id = :account_id AND date_of_night = :date_of_night order by created")
     public abstract ImmutableList<TimelineFeedback> getForNight(@Bind("account_id") final Long accountId, @Bind("date_of_night") final DateTime dateOfNight);
+
+    @SqlQuery("SELECT * FROM timeline_feedback WHERE date_of_night >= :tstartUTC and date_of_night < :tstopUTC")
+    public abstract ImmutableList<TimelineFeedback> getForTimeRange(@Bind("start_time") final Long tstartUTC, @Bind("stop_time") final Long tstopUTC);
 
 
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/db/mappers/TimelineFeedbackMapper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/mappers/TimelineFeedbackMapper.java
@@ -1,5 +1,6 @@
 package com.hello.suripu.core.db.mappers;
 
+import com.google.common.base.Optional;
 import com.hello.suripu.core.models.Event;
 import com.hello.suripu.core.models.TimelineFeedback;
 import org.joda.time.DateTime;
@@ -13,11 +14,19 @@ import java.sql.SQLException;
 public class TimelineFeedbackMapper implements ResultSetMapper<TimelineFeedback>{
     @Override
     public TimelineFeedback map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+
+        final DateTime dateOfNight = new DateTime(r.getTimestamp("date_of_night"), DateTimeZone.UTC);
+        final Long accountId = r.getLong("account_id");
+        final String oldTime = r.getString("old_time");
+        final String newTime = r.getString("new_time");
+        final Event.Type eventType = Event.Type.fromInteger(r.getInt("event_type"));
+
         return TimelineFeedback.create(
-                new DateTime(r.getTimestamp("date_of_night"), DateTimeZone.UTC),
-                r.getString("old_time"),
-                r.getString("new_time"),
-                Event.Type.fromInteger(r.getInt("event_type"))
+                dateOfNight,
+                oldTime,
+                newTime,
+                eventType,
+                accountId
         );
     }
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/TimelineFeedback.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/TimelineFeedback.java
@@ -2,6 +2,7 @@ package com.hello.suripu.core.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -11,12 +12,14 @@ public class TimelineFeedback {
     public final String oldTimeOfEvent;
     public final String newTimeOfEvent;
     public final Event.Type eventType;
+    public final Optional<Long> accountId;
 
-    private TimelineFeedback(final DateTime dateOfNight, final String oldTimeOfEvent, final String newTimeOfEvent, final Event.Type eventType) {
+    private TimelineFeedback(final DateTime dateOfNight, final String oldTimeOfEvent, final String newTimeOfEvent, final Event.Type eventType, final Optional<Long> accountId) {
         this.dateOfNight= dateOfNight;
         this.oldTimeOfEvent = oldTimeOfEvent;
         this.newTimeOfEvent = newTimeOfEvent;
         this.eventType = eventType;
+        this.accountId = accountId;
     }
 
     @JsonCreator
@@ -28,10 +31,14 @@ public class TimelineFeedback {
 
         final DateTime date = DateTime.parse(dateOfNight).withZone(DateTimeZone.UTC);
         final Event.Type eventType = Event.Type.fromString(eventTypeString);
-        return new TimelineFeedback(date, oldTimeOfEvent, newTimeOfEvent, eventType);
+        return new TimelineFeedback(date, oldTimeOfEvent, newTimeOfEvent, eventType, Optional.<Long>absent());
     }
 
     public static TimelineFeedback create(final DateTime dateOfNight, final String oldTimeOfEvent, final String newTimeOfEvent, final Event.Type eventType) {
-        return new TimelineFeedback(dateOfNight,oldTimeOfEvent,newTimeOfEvent,eventType);
+        return new TimelineFeedback(dateOfNight,oldTimeOfEvent,newTimeOfEvent,eventType,Optional.<Long>absent());
+    }
+
+    public static TimelineFeedback create(final DateTime dateOfNight, final String oldTimeOfEvent, final String newTimeOfEvent, final Event.Type eventType, final Long accountId) {
+        return new TimelineFeedback(dateOfNight,oldTimeOfEvent,newTimeOfEvent,eventType,Optional.of(accountId));
     }
 }


### PR DESCRIPTION
also added query for getting all feedbacks between certain times

I need this for joining feedbacks with timeline logs so I can determine algorithm performance from user feedback.

This was tested by verifying that timeline feedback still works, (both submitting feedback and seeing it affect the timeline output) so nothing was broken.
