### PR TITLE
Store timezone id and remove offset from string for smart alarm log

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/RingProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/RingProcessor.java
@@ -369,7 +369,8 @@ public class RingProcessor {
                 }
                 smartAlarmLoggerDynamoDB.log(accountId, lastCycleEnds, DateTime.now().withZone(timeZone),
                         smartAlarmRingTimeUTC.withZone(timeZone),
-                        new DateTime(nextRegularRingTime.expectedRingTimeUTC, timeZone));
+                        new DateTime(nextRegularRingTime.expectedRingTimeUTC, timeZone),
+                        timeZone);
             }
             LOGGER.info("User {} smartAlarm time is {}", accountId, new DateTime(smartAlarmRingTimeUTC, timeZone));
             nextRingTimeMillis = smartAlarmRingTimeUTC.getMillis();


### PR DESCRIPTION
@pims The current scheme for storing timestamp as string posts the following limits:
1) When restore the string to a DateTime object, JodaTime will get the correct time in default timezone, instead of the target timezone. The original timezone will not be preserved in the converted DateTime object.
2) When doing a scan/range query for > sometime_string1 && <= sometime_string2, we have to add +9999 to sometime_string2's timezone offset or we can't get the full range.

The solution is bring back the timezone id stored for each record, as an additional column, and get rid of the timezone offset in the string.
