### PR TITLE
Adding SQL table for sense colors

### DIFF
--- a/sql/common/create.sql
+++ b/sql/common/create.sql
@@ -244,3 +244,11 @@ CREATE TABLE onboarding_logs (
 GRANT ALL PRIVILEGES ON onboarding_logs TO ingress_user;
 GRANT ALL PRIVILEGES ON SEQUENCE onboarding_logs_id_seq TO ingress_user;
 CREATE UNIQUE INDEX unique_sense_id_time ON onboarding_logs(sense_id, account_id, utc_ts);
+
+
+
+CREATE TABLE sense_colors (id SERIAL PRIMARY KEY, sense_id VARCHAR(64),color VARCHAR(64));
+CREATE UNIQUE index sense_id_color on sense_colors(sense_id);
+
+GRANT ALL PRIVILEGES ON sense_colors TO ingress_user;
+GRANT ALL PRIVILEGES ON SEQUENCE sense_colors_id_seq TO ingress_user;

--- a/suripu-admin/src/main/java/com/hello/suripu/admin/SuripuAdmin.java
+++ b/suripu-admin/src/main/java/com/hello/suripu/admin/SuripuAdmin.java
@@ -49,6 +49,8 @@ import com.hello.suripu.core.db.SensorsViewsDynamoDB;
 import com.hello.suripu.core.db.TeamStore;
 import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.UserLabelDAO;
+import com.hello.suripu.core.db.colors.SenseColorDAO;
+import com.hello.suripu.core.db.colors.SenseColorDAOSQLImpl;
 import com.hello.suripu.core.db.util.JodaArgumentFactory;
 import com.hello.suripu.core.db.util.PostgresIntegerArrayArgumentFactory;
 import com.hello.suripu.core.logging.DataLogger;
@@ -128,6 +130,8 @@ public class SuripuAdmin extends Service<SuripuAdminConfiguration> {
         final PillHeartBeatDAO pillHeartBeatDAO = commonDB.onDemand(PillHeartBeatDAO.class);
         final OnBoardingLogDAO onBoardingLogDAO = commonDB.onDemand(OnBoardingLogDAO.class);
         final AccountDAOAdmin accountDAOAdmin = commonDB.onDemand(AccountDAOAdmin.class);
+
+        final SenseColorDAO senseColorDAO = commonDB.onDemand(SenseColorDAOSQLImpl.class);
 
         final ImmutableMap<DynamoDBTableName, String> tableNames = configuration.dynamoDBConfiguration().tables();
         final AmazonDynamoDB mergedUserInfoDynamoDBClient = dynamoDBClientFactory.getForTable(DynamoDBTableName.ALARM_INFO);
@@ -218,7 +222,8 @@ public class SuripuAdmin extends Service<SuripuAdminConfiguration> {
 
         environment.addResource(new PingResource());
         environment.addResource(new AccountResources(accountDAO, passwordResetDB, deviceDAO, accountDAOAdmin));
-        environment.addResource(new DeviceResources(deviceDAO, deviceDAOAdmin, deviceDataDAO, trackerMotionDAO, accountDAO, mergedUserInfoDynamoDB, senseKeyStore, pillKeyStore, jedisPool, pillHeartBeatDAO));
+        environment.addResource(new DeviceResources(deviceDAO, deviceDAOAdmin, deviceDataDAO, trackerMotionDAO, accountDAO,
+                mergedUserInfoDynamoDB, senseKeyStore, pillKeyStore, jedisPool, pillHeartBeatDAO, senseColorDAO));
         environment.addResource(new DataResources(deviceDataDAO, deviceDAO, accountDAO, userLabelDAO, trackerMotionDAO, sensorsViewsDynamoDB));
         environment.addResource(new ApplicationResources(applicationStore));
         environment.addResource(new FeaturesResources(featureStore));
@@ -232,7 +237,8 @@ public class SuripuAdmin extends Service<SuripuAdminConfiguration> {
                 new PCHResources(
                         senseKeyStoreDynamoDBClient, // we use the same endpoint for Sense and Pill keystore
                         tableNames.get(DynamoDBTableName.SENSE_KEY_STORE),
-                        tableNames.get(DynamoDBTableName.PILL_KEY_STORE)
+                        tableNames.get(DynamoDBTableName.PILL_KEY_STORE),
+                        senseColorDAO
                 )
         );
     }

--- a/suripu-admin/src/main/java/com/hello/suripu/admin/resources/v1/PCHResources.java
+++ b/suripu-admin/src/main/java/com/hello/suripu/admin/resources/v1/PCHResources.java
@@ -4,7 +4,10 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
+import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
+import com.hello.suripu.core.db.colors.SenseColorDAO;
+import com.hello.suripu.core.models.Device;
 import com.hello.suripu.core.oauth.AccessToken;
 import com.hello.suripu.core.oauth.OAuthScope;
 import com.hello.suripu.core.oauth.Scope;
@@ -14,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,13 +32,17 @@ public class PCHResources {
 
     private final AmazonDynamoDB amazonDynamoDB;
     private final String senseKeyStoreTableName;
+    private final SenseColorDAO senseColorDAO;
     private final String pillKeyStoreTableName;
     private final static Integer SCAN_QUERY_LIMIT = 5000;
+    private final static String WHITE_SENSE_PREFIX = "91000008W";
+    private final static String BLACK_SENSE_PREFIX = "91000008B";
 
-    public PCHResources(final AmazonDynamoDB amazonDynamoDB, final String senseKeyStoreTableName, final String pillKeyStoreTableName) {
+    public PCHResources(final AmazonDynamoDB amazonDynamoDB, final String senseKeyStoreTableName, final String pillKeyStoreTableName, final SenseColorDAO senseColorDAO) {
         this.amazonDynamoDB = amazonDynamoDB;
         this.senseKeyStoreTableName = senseKeyStoreTableName;
         this.pillKeyStoreTableName = pillKeyStoreTableName;
+        this.senseColorDAO = senseColorDAO;
     }
 
     @POST
@@ -134,4 +142,69 @@ public class PCHResources {
 
         return sb.toString();
     }
+
+
+    @GET
+    @Path("/colors")
+    public String updateSenseColors(@Scope(OAuthScope.ADMINISTRATION_WRITE) final AccessToken accessToken) {
+
+        Map<String, AttributeValue> lastKeyEvaluated = null;
+        int count = 0;
+        int i = 0;
+        do {
+            LOGGER.info("Scanning table: {}. Iteration # {}. Store size: {}", senseKeyStoreTableName, i, count);
+
+            final ScanRequest scanRequest = new ScanRequest()
+                    .withTableName(senseKeyStoreTableName)
+                    .withAttributesToGet("device_id", "metadata")
+                    .withExclusiveStartKey(lastKeyEvaluated)
+                    .withLimit(SCAN_QUERY_LIMIT);
+
+            final ScanResult scanResult = amazonDynamoDB.scan(scanRequest);
+            lastKeyEvaluated = scanResult.getLastEvaluatedKey();
+            LOGGER.info("Last key: {}", lastKeyEvaluated);
+            for (final Map<String, AttributeValue> map : scanResult.getItems()) {
+                if(map.containsKey("metadata") && map.containsKey("device_id")) {
+                    // This a potential race condition but since colors are immutable that's not really an issue
+                    final Optional<Device.Color> colorOptional = senseColorDAO.getColorForSense(map.get("device_id").getS());
+                    if(!colorOptional.isPresent()) {
+                        final String sn = map.get("metadata").getS();
+                        senseColorDAO.saveColorForSense(map.get("device_id").getS(), fromSN(map.get("device_id").getS(), sn).name());
+                    }
+                }
+                count ++;
+            }
+
+            try {
+                Thread.sleep(1000L);
+            } catch (InterruptedException e) {
+                LOGGER.error("{}", e.getMessage());
+                return "FAILED";
+            }
+            i++;
+        } while(lastKeyEvaluated != null);
+
+
+        return "OK";
+    }
+
+
+    public static Device.Color fromSN(final String senseId, final String serialNumber) {
+
+        if(serialNumber.length() < BLACK_SENSE_PREFIX.length()) {
+            return Device.Color.BLACK;
+        }
+
+        final String prefix = serialNumber.toUpperCase().substring(0, BLACK_SENSE_PREFIX.length());
+        if(WHITE_SENSE_PREFIX.equals(prefix)) {
+            return Device.Color.WHITE;
+        } else if(BLACK_SENSE_PREFIX.equals(prefix)) {
+            return Device.Color.BLACK;
+        }
+
+        LOGGER.warn("Unknown color for sense {} with SN: {}", senseId, serialNumber);
+        return Device.Color.BLACK;
+    }
+
+
 }


### PR DESCRIPTION
:warning: **DO NOT MERGE. SQL TABLE NOT CREATED IN PRODUCTION** :warning: 

Goal:
1. provide endpoint AND db access to know what color a given Sense is
2. provide the ability to override the color of a given Sense (why? for Sense manually provisioned)
3. provide endpoint to automatically insert color for new Senses

Non Goal:
1. Be an immutable source of Sense colors.

cc @longd3 @benejoseph 
