### PR TITLE
Renaming the always_ota_release feature

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -8,7 +8,7 @@ public class FeatureFlipper {
     public final static String SOUND_INFO_TIMELINE = "sound_info_timeline";
     public final static String SMART_ALARM = "smart_alarm";
     public final static String OTA_RELEASE = "release";
-    public final static String ALWAYS_OTA_RELEASE = "always_ota_release";
+    public final static String BYPASS_OTA_CHECKS = "bypass_ota_checks";
     public final static String FORCE_EVT_OTA_UPDATE = "pang-fire-fighting";
     public final static String DEBUG_MODE_PILL_PAIRING = "debug-mode-pill-pairing";
     public final static String MISSING_DATA_DEFAULT_VALUE = "missing_data_default_value";

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/OTAProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/OTAProcessor.java
@@ -58,7 +58,7 @@ public class OTAProcessor {
                                        final DateTime currentDTZ,
                                        final DateTime startOTAWindow,
                                        final DateTime endOTAWindow,
-                                       final Boolean isAlwaysOTA,
+                                       final Boolean bypassOTAChecks,
                                        final String ipAddress) {
 
         boolean canOTA;
@@ -68,8 +68,8 @@ public class OTAProcessor {
                 return false;
         }
 
-        if (isAlwaysOTA) {
-            LOGGER.info("Always OTA is on for device: {}", deviceID);
+        if (bypassOTAChecks) {
+            LOGGER.info("OTA checks are bypassed for device: {}", deviceID);
             canOTA = true;
         } else {
 

--- a/suripu-service/src/main/java/com/hello/suripu/service/resources/ReceiveResource.java
+++ b/suripu-service/src/main/java/com/hello/suripu/service/resources/ReceiveResource.java
@@ -341,7 +341,7 @@ public class ReceiveResource extends BaseResource {
             }
 
 
-            if (featureFlipper.deviceFeatureActive(FeatureFlipper.ALWAYS_OTA_RELEASE, deviceName, groups) || groups.contains("chris-dev")) {
+            if (featureFlipper.deviceFeatureActive(FeatureFlipper.BYPASS_OTA_CHECKS, deviceName, groups) || groups.contains("chris-dev")) {
                 responseBuilder.setBatchSize(1);
             } else {
 
@@ -525,7 +525,7 @@ public class ReceiveResource extends BaseResource {
         final DateTime endOTAWindow = new DateTime(userTimeZone).withHourOfDay(otaConfiguration.getEndUpdateWindowHour()).withMinuteOfHour(0);
         final Set<String> alwaysOTAGroups = otaConfiguration.getAlwaysOTAGroups();
         final Integer deviceUptimeDelay = otaConfiguration.getDeviceUptimeDelay();
-        final Boolean alwaysOTA = (featureFlipper.deviceFeatureActive(FeatureFlipper.ALWAYS_OTA_RELEASE, deviceID, deviceGroups));
+        final Boolean bypassOTAChecks = (featureFlipper.deviceFeatureActive(FeatureFlipper.BYPASS_OTA_CHECKS, deviceID, deviceGroups));
         final String ipAddress = getIpAddress(request);
 
         final List<String> ipGroups = groupFlipper.getGroups(ipAddress);
@@ -549,7 +549,7 @@ public class ReceiveResource extends BaseResource {
             }
         }
 
-        final boolean canOTA = OTAProcessor.canDeviceOTA(deviceID, deviceGroups, ipGroups, alwaysOTAGroups, deviceUptimeDelay, uptimeInSeconds, currentDTZ, startOTAWindow, endOTAWindow, alwaysOTA, ipAddress);
+        final boolean canOTA = OTAProcessor.canDeviceOTA(deviceID, deviceGroups, ipGroups, alwaysOTAGroups, deviceUptimeDelay, uptimeInSeconds, currentDTZ, startOTAWindow, endOTAWindow, bypassOTAChecks, ipAddress);
 
         if(canOTA) {
 


### PR DESCRIPTION
Very minor, but the feature 'always_ota_release' is NOT used to always OTA the Release. It actually is used as a bypass for all OTA checks. I want this to be clearer to reduce confusion in the future. 

@pims Review, please?
