### PR TITLE
remove grey-out events, feature-flipped

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -33,6 +33,7 @@ public class FeatureFlipper {
     public final static String EXTRA_EVENTS = "extra_events";
     public final static String SENSE_LAST_SEEN_VIEW_DYNAMODB = "sense_last_seen_view_dynamodb";
     public final static String REMOVE_MOTION_EVENTS_OUTSIDE_SLEEP = "remove_motion_events_outside_sleep";
+    public final static String REMOVE_GREY_OUT_EVENTS = "remove_grey_out_events";
 
     public final static String REBOOT_CLOCK_OUT_OF_SYNC_DEVICES = "reboot_clock_out_of_sync_devices";
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/FeatureFlippedProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/FeatureFlippedProcessor.java
@@ -62,4 +62,9 @@ public class FeatureFlippedProcessor {
     protected Boolean hasRemoveMotionEventsOutsideSleep(final Long accountId) {
         return featureFlipper.userFeatureActive(FeatureFlipper.REMOVE_MOTION_EVENTS_OUTSIDE_SLEEP, accountId, Collections.EMPTY_LIST);
     }
+
+    protected Boolean hasRemoveGreyOutEvents(final Long accountId) {
+        return featureFlipper.userFeatureActive(FeatureFlipper.REMOVE_GREY_OUT_EVENTS, accountId, Collections.EMPTY_LIST);
+    }
+
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -473,8 +473,27 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         }
 
         /* add sleep/wake events  */
+
+        // if user feedback available, use them, otherwise stick to times from algorithm
+        Optional<Event> inBedEventOptional = sleepEventsFromAlgorithm.goToBed;
+        Optional<Event> outBedOptional = sleepEventsFromAlgorithm.outOfBed;
+        Optional<Event> sleepEventOptional = sleepEventsFromAlgorithm.fallAsleep;
+        Optional<Event> awakeEventOptional = sleepEventsFromAlgorithm.wakeUp;
+
         for (final Event event : sleepEventsModifiedByFeedback) {
             timelineEvents.put(event.getStartTimestamp(), event);
+
+            // adjust event times to use feedback times
+            if (event.getType() == Event.Type.IN_BED) {
+                inBedEventOptional = Optional.of(event);
+            } else if (event.getType() == Event.Type.OUT_OF_BED) {
+                outBedOptional = Optional.of(event);
+            } else if (event.getType() == Event.Type.SLEEP) {
+                sleepEventOptional = Optional.of(event);
+            } else if (event.getType() == Event.Type.WAKE_UP) {
+                awakeEventOptional = Optional.of(event);
+            }
+
         }
 
         /*  add "additional" events -- which is wake/sleep/get up to pee events */
@@ -486,23 +505,30 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         final List<Event> eventsWithSleepEvents = TimelineRefactored.mergeEvents(timelineEvents);
         final List<Event> smoothedEvents = timelineUtils.smoothEvents(eventsWithSleepEvents);
 
+
+        /* clean up timeline */
+
+        // 1. remove motion & null events outside sleep/in-bed period
         List<Event> cleanedUpEvents;
         if (this.hasRemoveMotionEventsOutsideSleep(accountId)) {
             // remove motion events outside of sleep and awake
-            cleanedUpEvents = timelineUtils.removeMotionEventsOutsideSleep(smoothedEvents,
-                    sleepEventsFromAlgorithm.fallAsleep,
-                    sleepEventsFromAlgorithm.wakeUp);
+            cleanedUpEvents = timelineUtils.removeMotionEventsOutsideSleep(smoothedEvents, sleepEventOptional, awakeEventOptional);
         } else {
             // remove motion events outside of in-bed and out-bed
-            cleanedUpEvents = timelineUtils.removeMotionEventsOutsideBedPeriod(smoothedEvents,
-                    sleepEventsFromAlgorithm.goToBed,
-                    sleepEventsFromAlgorithm.outOfBed);
+            cleanedUpEvents = timelineUtils.removeMotionEventsOutsideBedPeriod(smoothedEvents, inBedEventOptional, outBedOptional);
         }
 
+        // 2. Grey out events outside in-bed time
+        final Boolean removeGreyOutEvents = this.hasRemoveGreyOutEvents(accountId); // rm grey events totally
+
         final List<Event> greyEvents = timelineUtils.greyNullEventsOutsideBedPeriod(cleanedUpEvents,
-                sleepEventsFromAlgorithm.goToBed,
-                sleepEventsFromAlgorithm.outOfBed);
+                inBedEventOptional, outBedOptional, removeGreyOutEvents);
+
+        // 3. remove non-significant that are more than 1/3 of the entire night's time-span
         final List<Event> nonSignificantFilteredEvents = timelineUtils.removeEventBeforeSignificant(greyEvents);
+
+
+        /* convert valid events to segment, compute sleep stats and score */
 
         final List<SleepSegment> sleepSegments = timelineUtils.eventsToSegments(nonSignificantFilteredEvents);
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/util/TimelineUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/TimelineUtils.java
@@ -324,24 +324,38 @@ public class TimelineUtils {
 
     public List<Event> greyNullEventsOutsideBedPeriod(final List<Event> events,
                                                                  final Optional<Event> inBedEventOptional,
-                                                                 final Optional<Event> outOfBedEventOptional){
+                                                                 final Optional<Event> outOfBedEventOptional,
+                                                                 final Boolean removeGreyOutEvents){
         final LinkedList<Event> newEventList = new LinkedList<>();
 
         // State is harmful, shall avoid it like plague
         for(final Event event:events){
-            if(event.getType() != Event.Type.NONE){
-                newEventList.add(event);
-                continue;
+
+            final Event.Type eventType = event.getType();
+            if (eventType != Event.Type.NONE) {
+                if (removeGreyOutEvents && eventType != Event.Type.MOTION) {
+                    newEventList.add(event);
+                    continue;
+                } else {
+                    // for backward compatibility
+                    newEventList.add(event);
+                    continue;
+                }
             }
+
 
             // This is a null event, shall we keep it as it is?
             if(inBedEventOptional.isPresent() && event.getEndTimestamp() <= inBedEventOptional.get().getStartTimestamp()){
-                newEventList.add(event);  // Null event before in bed, grey
+                if (!removeGreyOutEvents) {
+                    newEventList.add(event);  // Null event before in bed, grey
+                }
                 continue;
             }
 
             if(outOfBedEventOptional.isPresent() && event.getStartTimestamp() >= outOfBedEventOptional.get().getEndTimestamp()){
-                newEventList.add(event);  // Null event after out of bed, grey
+                if (!removeGreyOutEvents) {
+                    newEventList.add(event);  // Null event after out of bed, grey
+                }
                 continue;
             }
 


### PR DESCRIPTION
1. remove all motion and null events (grey) from before in-bed and after out-bed events (issue 245)
2. use feedback times for filtering (should fix issue 264)
