### PR TITLE
Get rid of the expensive query

### DIFF
--- a/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineRecordProcessor.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineRecordProcessor.java
@@ -166,12 +166,6 @@ public class TimelineRecordProcessor extends HelloBaseRecordProcessor {
     private void batchProcess(final Map<Long, Set<DateTime>> groupedAccountIdTargetDateLocalUTCMap){
         for(final Long accountId:groupedAccountIdTargetDateLocalUTCMap.keySet()) {
             for(final DateTime targetDateLocalUTC:groupedAccountIdTargetDateLocalUTCMap.get(accountId)) {
-                if (this.timelineProcessor.shouldProcessTimelineByWorker(accountId,
-                        this.configuration.getMaxNoMoitonPeriodInMinutes(),
-                        DateTime.now())) {
-                    continue;
-                }
-
                 try {
                     final Optional<TimelineResult> result = this.timelineProcessor.retrieveTimelinesFast(accountId, targetDateLocalUTC);
                     if(!result.isPresent()){


### PR DESCRIPTION
@kingshyg The query of TrackerMotionDAO.getLast  `SELECT * FROM tracker_motion_master WHERE account_id = 1648 ORDER BY ts DESC LIMIT 1;` is very expensive:

```
sensors1=> explain analyze SELECT * FROM tracker_motion_master WHERE account_id = 1648 ORDER BY ts DESC LIMIT 1;
                                                                     QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=206359.90..206359.90 rows=1 width=64) (actual time=1980.332..1980.335 rows=1 loops=1)
   ->  Sort  (cost=206359.90..206364.98 rows=2032 width=64) (actual time=1980.326..1980.326 rows=1 loops=1)
         Sort Key: tracker_motion_master.ts
         Sort Method: top-N heapsort  Memory: 25kB
         ->  Append  (cost=0.00..206349.74 rows=2032 width=64) (actual time=41.546..1973.268 rows=5744 loops=1)
               ->  Seq Scan on tracker_motion_master  (cost=0.00..0.00 rows=1 width=64) (actual time=0.001..0.001 rows=0 loops=1)
                     Filter: (account_id = 1648)
               ->  Seq Scan on tracker_motion_par_default  (cost=0.00..59307.60 rows=1159 width=64) (actual time=41.536..601.104 rows=3786 loops=1)
                     Filter: (account_id = 1648)
                     Rows Removed by Filter: 2377582
               ->  Seq Scan on tracker_motion_par_2015_05  (cost=0.00..147042.14 rows=872 width=64) (actual time=2.549..1360.885 rows=1958 loops=1)
                     Filter: (account_id = 1648)
                     Rows Removed by Filter: 5901503
 Total runtime: 1980.462 ms
(14 rows)
```

However I don't want to build another index on the tracker motion table now. So as a temp fix I just get rid of that query.
