### PR TITLE
Display different no sleep data wording based on different discard reasons

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/InvalidNightType.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/InvalidNightType.java
@@ -1,0 +1,11 @@
+package com.hello.suripu.core.util;
+
+/**
+ * Created by pangwu on 6/4/15.
+ */
+public enum InvalidNightType {
+    VALID,
+    TIMESPAN_TOO_SHORT,
+    LOW_AMP_DATA,
+    NO_DATA
+}


### PR DESCRIPTION
Previously if a person has all low amp data or data only spread in a short time period the timeline screen will all show 'has some data but no enough to generate timeline'.

With this fix only data spread in a short time span and has amplitude above certain threshold will display that message. Otherwise all display no sleep data (see James night of 06/02/2015).

Test result for James night of 06/02:

```
ubuntu@ip-10-0-1-162:~$ curl 'http://127.0.0.1:9999/v1/timeline/2015-06-02' -i -H 'Authorization : Bearer 3.xxxxxxxxxxxx'
HTTP/1.1 200 OK
Date: Thu, 04 Jun 2015 20:25:14 GMT
Content-Type: application/json
Cache-Control: no-cache
Transfer-Encoding: chunked

[{"score":0,"message":" No sleep data recorded","date":"","segments":[],"insights":[],"statistics":null}]
```
