### PR TITLE
Bring back never expire timeline cache

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/TimelineDAODynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/TimelineDAODynamoDB.java
@@ -382,7 +382,7 @@ public class TimelineDAODynamoDB {
                 item.put(TARGET_DATE_OF_NIGHT_ATTRIBUTE_NAME, new AttributeValue().withN(String.valueOf(targetDateOfNightLocalUTC)));
                 item.put(UPDATED_AT_ATTRIBUTE_NAME, new AttributeValue().withN(String.valueOf(DateTime.now().getMillis())));
                 item.put(VERSION, new AttributeValue().withS(TimelineProcessor.VERSION));
-                item.put(EXPIRED_AT_MILLIS, new AttributeValue().withN(String.valueOf(CachedTimelines.NEVER_EXPIRE)));
+                item.put(EXPIRED_AT_MILLIS, new AttributeValue().withN(String.valueOf(DateTime.now().plusDays(3).getMillis())));
 
                 final int compressType = Compression.CompressionType.NONE.getValue();
                 item.put(COMPRESS_TYPE_ATTRIBUTE_NAME, new AttributeValue().withN(


### PR DESCRIPTION
@pims Now the cache expire every 3 hours, since we already figured out the never working cache problem we should bring it back so the cache hit for previous days could go up.
