### PR TITLE
Filtering the devices seen by range in addition to the fw versions seen

### DIFF
--- a/suripu-admin/src/main/java/com/hello/suripu/admin/resources/v1/FirmwareResource.java
+++ b/suripu-admin/src/main/java/com/hello/suripu/admin/resources/v1/FirmwareResource.java
@@ -209,7 +209,7 @@ public class FirmwareResource {
             final Pipeline pipe = jedis.pipelined();
             final Map<String, redis.clients.jedis.Response<Long>> responseMap = Maps.newHashMap();
             for (final Tuple fwInfo:seenFirmwares) {
-                responseMap.put(fwInfo.getElement(), pipe.zcard(fwInfo.getElement()));
+                responseMap.put(fwInfo.getElement(), pipe.zcount(fwInfo.getElement(), rangeStart, rangeEnd));
             }
             pipe.sync();
             for (final Tuple fwInfo:seenFirmwares) {


### PR DESCRIPTION
This makes the counts returned by the /list_by_time endpoint reflect the number of devices seen in that same time period instead of a total count of devices ever seen on that fw. This makes more sense. 

@pims Review, please. Not urgent. 
