### PR TITLE
Always process timeline for admin queries

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/TimelineResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/TimelineResource.java
@@ -175,9 +175,11 @@ public class TimelineResource extends BaseResource {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
 
-        final TimelineResult result = getTimelinesFromCacheOrReprocess(UUID.randomUUID(), accountId.get(), date);
-
-        return result.timelines;
+        final Optional<TimelineResult> timelineResultOptional = timelineProcessor.retrieveTimelinesFast(accountId.get(), DateTimeUtil.ymdStringToDateTime(date));
+        if (!timelineResultOptional.isPresent()) {
+            return TimelineResult.createEmpty().timelines;
+        }
+        return timelineResultOptional.get().timelines;
     }
 
     @Timed


### PR DESCRIPTION
Rather than use cache @pims 
