### PR TITLE
Add endpoint to set timezone by partner timezone if necessary

### DIFF
--- a/suripu-admin/src/main/java/com/hello/suripu/admin/resources/v1/DeviceResources.java
+++ b/suripu-admin/src/main/java/com/hello/suripu/admin/resources/v1/DeviceResources.java
@@ -891,28 +891,32 @@ public class DeviceResources {
                                              @NotNull @PathParam("account_id") final Long accountId){
 
         final Optional<Long> partnerAccountIdOptional = deviceDAO.getPartnerAccountId(accountId);
-
         if (!partnerAccountIdOptional.isPresent()) {
+            LOGGER.warn("Cannot update timezone by partner for {} - Partner not found", accountId);
             throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Partner not found").build());
         }
 
         final Optional<DeviceAccountPair> deviceAccountPairOptional = deviceDAO.getMostRecentSensePairByAccountId(accountId);
         if (!deviceAccountPairOptional.isPresent()) {
+            LOGGER.warn("Cannot update timezone by partner for {} - No sense paired to this account", accountId);
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("No sense paired to this account").build());
         }
         final Optional<DateTimeZone> timeZoneOptional = mergedUserInfoDynamoDB.getTimezone(deviceAccountPairOptional.get().externalDeviceId, accountId);
 
         if (timeZoneOptional.isPresent()) {
+            LOGGER.warn("Cannot update timezone by partner for {} - This account already got a timezone", accountId);
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("This account already got a timezone").build());
         }
 
         final Optional<DeviceAccountPair> partnerdeviceAccountPairOptional = deviceDAO.getMostRecentSensePairByAccountId(partnerAccountIdOptional.get());
         if (!partnerdeviceAccountPairOptional.isPresent()) {
+            LOGGER.warn("Cannot update timezone by partner for {} - Partner does not have a sense", accountId);
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("No sense paired to partner account").build());
         }
         final Optional<DateTimeZone> partnerTimeZoneOptional = mergedUserInfoDynamoDB.getTimezone(partnerdeviceAccountPairOptional.get().externalDeviceId, partnerAccountIdOptional.get());
 
         if (!partnerAccountIdOptional.isPresent()){
+            LOGGER.warn("Cannot update timezone by partner for {} - Partner does not have a timezone", accountId);
             throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Partner does not have a timezone").build());
         }
 


### PR DESCRIPTION
Motivation: https://papertrailapp.com/groups/1334064/events?q=program%3Asuripu-workers-sense.log+no+timezone&r=558424894359253032-558432290267770902

At first, I think of https://github.com/hello/suripu/pull/1028 but it is much intrusive. Because @jimmymlu is gonna fix it on the client ultimately, that PR may not be needed.

For current people who do not have timezone, we should indentify them and update if they share senses with partners who have proper timezone . This PR gives an endpoint for a cron job to do that routinely.

@jnorgan: review please when you've a chane
