### PR TITLE
Removing particulate state from room condition evaluation

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/RoomConditionUtil.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/RoomConditionUtil.java
@@ -60,14 +60,13 @@ public class RoomConditionUtil {
         float warningCount = 0;
         float alertCount = 0;
 
+        //TODO: Add particulate values back into room condition after it becomes visible to the user
         warningCount += getWarningCountFromSate(currentRoomState.humidity);
-        warningCount += getWarningCountFromSate(currentRoomState.particulates);
         warningCount += getWarningCountFromSate(currentRoomState.temperature);
         warningCount += getWarningCountFromSate(currentRoomState.light);
         warningCount += getWarningCountFromSate(currentRoomState.sound);
 
         alertCount += getAlertCountFromSate(currentRoomState.humidity);
-        alertCount += getAlertCountFromSate(currentRoomState.particulates);
         alertCount += getAlertCountFromSate(currentRoomState.temperature);
         alertCount += getAlertCountFromSate(currentRoomState.light);
         alertCount += getAlertCountFromSate(currentRoomState.sound);


### PR DESCRIPTION
This isn't visible to the user, so let's not confuse users by having it influence the room condition color. 

@pims Review, please. 
