### PR TITLE
Filters out recently added preferences on V1 endpoint

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/AccountPreferencesResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/AccountPreferencesResource.java
@@ -1,5 +1,9 @@
 package com.hello.suripu.app.resources.v1;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
+import com.hello.suripu.core.models.ApiVersion;
 import com.hello.suripu.core.oauth.AccessToken;
 import com.hello.suripu.core.oauth.OAuthScope;
 import com.hello.suripu.core.oauth.Scope;
@@ -14,21 +18,32 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.HashMap;
 import java.util.Map;
 
 @Path("/v1/preferences")
 public class AccountPreferencesResource {
-
     private final AccountPreferencesDAO preferencesDAO;
 
     public AccountPreferencesResource(final AccountPreferencesDAO preferencesDAO) {
         this.preferencesDAO = preferencesDAO;
     }
 
+    @VisibleForTesting
+    static Map<PreferenceName, Boolean> filterEntries(Map<PreferenceName, Boolean> preferences) {
+        return Maps.filterEntries(preferences, new Predicate<Map.Entry<PreferenceName, Boolean>>() {
+            @Override
+            public boolean apply(Map.Entry<PreferenceName, Boolean> entry) {
+                final PreferenceName preference = entry.getKey();
+                return (preference.availableStarting == ApiVersion.V1);
+            }
+        });
+    }
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Map<PreferenceName, Boolean> get(@Scope(OAuthScope.PREFERENCES) final AccessToken accessToken) {
-        return preferencesDAO.get(accessToken.accountId);
+        return filterEntries(preferencesDAO.get(accessToken.accountId));
     }
 
     @PUT

--- a/suripu-app/src/test/java/com/hello/suripu/app/resources/v1/AccountPreferencesResourceTests.java
+++ b/suripu-app/src/test/java/com/hello/suripu/app/resources/v1/AccountPreferencesResourceTests.java
@@ -1,0 +1,38 @@
+package com.hello.suripu.app.resources.v1;
+
+import com.google.common.collect.Maps;
+import com.hello.suripu.core.preferences.PreferenceName;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+public class AccountPreferencesResourceTests {
+    @Test
+    public void filterEntries() {
+        Map<PreferenceName, Boolean> unfiltered = Maps.newHashMap();
+        unfiltered.put(PreferenceName.ENHANCED_AUDIO, true);
+        unfiltered.put(PreferenceName.TEMP_CELSIUS, true);
+        unfiltered.put(PreferenceName.TIME_TWENTY_FOUR_HOUR, true);
+        unfiltered.put(PreferenceName.PUSH_SCORE, true);
+        unfiltered.put(PreferenceName.PUSH_ALERT_CONDITIONS, true);
+        unfiltered.put(PreferenceName.WEIGHT_METRIC, true);
+        unfiltered.put(PreferenceName.HEIGHT_METRIC, true);
+
+        final Map<PreferenceName, Boolean> filtered = AccountPreferencesResource.filterEntries(unfiltered);
+        assertThat(filtered.keySet(), hasItems(
+                PreferenceName.ENHANCED_AUDIO,
+                PreferenceName.TEMP_CELSIUS,
+                PreferenceName.TIME_TWENTY_FOUR_HOUR,
+                PreferenceName.PUSH_SCORE,
+                PreferenceName.PUSH_ALERT_CONDITIONS
+        ));
+        assertThat(filtered.keySet(), not(hasItems(
+                PreferenceName.WEIGHT_METRIC,
+                PreferenceName.HEIGHT_METRIC
+        )));
+    }
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/ApiVersion.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/ApiVersion.java
@@ -1,0 +1,12 @@
+package com.hello.suripu.core.models;
+
+public enum ApiVersion {
+    V1(1),
+    V2(2);
+
+    public final int code;
+
+    ApiVersion(int code) {
+        this.code = code;
+    }
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/preferences/PreferenceName.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/preferences/PreferenceName.java
@@ -1,19 +1,23 @@
 package com.hello.suripu.core.preferences;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.hello.suripu.core.models.ApiVersion;
 
 public enum PreferenceName {
-    ENHANCED_AUDIO("enhanced_audio"),
-    TEMP_CELSIUS("temp_celsius"),
-    TIME_TWENTY_FOUR_HOUR("time_twenty_four_hour"),
-    PUSH_SCORE("push_score"),
-    PUSH_ALERT_CONDITIONS("push_alert_conditions"),
-    WEIGHT_METRIC("weight_metric"),
-    HEIGHT_METRIC("height_metric");
+    ENHANCED_AUDIO(ApiVersion.V1, "enhanced_audio"),
+    TEMP_CELSIUS(ApiVersion.V1, "temp_celsius"),
+    TIME_TWENTY_FOUR_HOUR(ApiVersion.V1, "time_twenty_four_hour"),
+    PUSH_SCORE(ApiVersion.V1, "push_score"),
+    PUSH_ALERT_CONDITIONS(ApiVersion.V1, "push_alert_conditions"),
+    WEIGHT_METRIC(ApiVersion.V2, "weight_metric"),
+    HEIGHT_METRIC(ApiVersion.V2, "height_metric");
 
+    public final ApiVersion availableStarting;
     private String value;
 
-    PreferenceName(final String value) {
+    PreferenceName(final ApiVersion availableStarting,
+                   final String value) {
+        this.availableStarting = availableStarting;
         this.value = value;
     }
 


### PR DESCRIPTION
suripu-android 1.1.1 has a faulty deserialization mechanism that will fail when more than one new key is added to the get account preferences response. this is fixed in 1.1.2 with the migration to the v2 endpoint – related PR https://github.com/hello/suripu-android/pull/165
