### PR TITLE
timelineprocessor: worker & timelinev2 log w/UUID

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/v2/TimelineResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/v2/TimelineResource.java
@@ -42,6 +42,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.UUID;
 
 @Path("/v2/timeline")
 public class TimelineResource extends BaseResource {
@@ -82,8 +83,11 @@ public class TimelineResource extends BaseResource {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
 
+
+        final TimelineProcessor timelineProcessorWithUUIDLogging = this.timelineProcessor.copyMeWithNewUUID(UUID.randomUUID());
+
         final DateTime targetDate = DateTimeUtil.ymdStringToDateTime(night);
-        final Optional<TimelineResult> timeline = timelineProcessor.retrieveTimelinesFast(accessToken.accountId, targetDate);
+        final Optional<TimelineResult> timeline = timelineProcessorWithUUIDLogging.retrieveTimelinesFast(accessToken.accountId, targetDate);
         if(!timeline.isPresent()) {
             return Timeline.createEmpty(targetDate);
         }

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineRecordProcessor.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/timeline/TimelineRecordProcessor.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -188,7 +189,11 @@ public class TimelineRecordProcessor extends HelloBaseRecordProcessor {
 
                 this.timelineReadyToProcess.mark(1);
                 try {
-                    final Optional<TimelineResult> result = this.timelineProcessor.retrieveTimelinesFast(accountId, targetDateLocalUTC);
+
+                    final TimelineProcessor timelineProcessorWithUUIDLogging = this.timelineProcessor.copyMeWithNewUUID(UUID.randomUUID());
+
+
+                    final Optional<TimelineResult> result = timelineProcessorWithUUIDLogging.retrieveTimelinesFast(accountId, targetDateLocalUTC);
                     if(!result.isPresent()){
                         this.emptyTimelineAfterProcess.mark(1);
                         continue;


### PR DESCRIPTION
The server logs for timeline no longer include UUID.  I need this to track the logging per user per request.
