### PR TITLE
JsonProperty on wrong method, fixes bug 469

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Account.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Account.java
@@ -234,13 +234,13 @@ public class Account {
             return this;
         }
 
-        @JsonIgnore
+        @JsonProperty("created")
         public Builder withCreated(final Long created) {
             this.created = new DateTime(created);
             return this;
         }
 
-        @JsonProperty("created")
+        @JsonIgnore
         public Builder withCreated(final DateTime created) {
             this.created = created;
             return this;


### PR DESCRIPTION
https://github.com/hello/bugs/issues/469#issuecomment-137278549

Client receives the created date as a long and sends up the value back as a long
