### PR TITLE
Staging config missing a needed value.

### DIFF
--- a/suripu-workers/configs/insights/insights_generator.staging.yml
+++ b/suripu-workers/configs/insights/insights_generator.staging.yml
@@ -167,6 +167,7 @@ sleep_stats_db:
     endpoint : http://dynamodb.us-east-1.amazonaws.com
     region : us-east-1
     table_name : sleep_stats
+sleep_stats_version: v_0_2
 
 kinesis_logger:
   stream_name: dev-logs


### PR DESCRIPTION
Adding a missing config value for sleep stats to staging config. This was causing a failure to start on dev. 

@pims
