### PR TITLE
Added wifi_info DB to yaml example

### DIFF
--- a/suripu-app/suripu-app.dev.yml.example
+++ b/suripu-app/suripu-app.dev.yml.example
@@ -265,6 +265,11 @@ calibration:
   region: us-east-1
   table_name: calibration
 
+wifi_info:
+  endpoint : http://localhost:7777
+  region: us-east-1
+  table_name: wifi_info
+
 app_stats:
   endpoint : http://localhost:7777
   region: us-east-1


### PR DESCRIPTION
wifi_info was missing from suripu-app.dev.yml.example
