### PR TITLE
query speedup

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDataDAO.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDataDAO.java
@@ -164,8 +164,10 @@ public abstract class DeviceDataDAO {
 
     @RegisterMapper(DeviceDataMapper.class)
     @SqlQuery("SELECT * FROM device_sensors_master " +
-            "WHERE account_id = :account_id AND device_id = :device_id AND ambient_light > :light_level " +
+            "WHERE account_id = :account_id AND device_id = :device_id " +
+            "AND ambient_light > :light_level " +
             "AND ts >= :start_ts AND ts <= :end_ts " +
+            "AND local_utc_ts >= :start_local_utc_ts AND local_utc_ts <= :end_local_utc_ts" +
             "AND (CAST(date_part('hour', local_utc_ts) AS integer) >= :start_hour " +
             "OR CAST(date_part('hour', local_utc_ts) AS integer) < :end_hour) " +
             "ORDER BY ts")
@@ -174,6 +176,8 @@ public abstract class DeviceDataDAO {
                                                                             @Bind("light_level") int lightLevel,
                                                                             @Bind("start_ts") DateTime startTimestamp,
                                                                             @Bind("end_ts") DateTime endTimestamp,
+                                                                            @Bind("start_local_utc_ts") DateTime startLocalTimeStamp,
+                                                                            @Bind("end_local_utc_ts") DateTime endLocalTimeStamp,
                                                                             @Bind("start_hour") int startHour,
                                                                             @Bind("end_hour") int endHour);
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/BedLightDuration.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/BedLightDuration.java
@@ -146,8 +146,11 @@ public class BedLightDuration {
         final DateTime queryEndTime = DateTime.now(DateTimeZone.forOffsetMillis(timeZoneOffset)).withHourOfDay(NIGHT_START_HOUR_LOCAL);
         final DateTime queryStartTime = queryEndTime.minusDays(InsightCard.PAST_WEEK);
 
+        final DateTime queryEndTimeLocal = queryEndTime.plusMillis(timeZoneOffset);
+        final DateTime queryStartTimeLocal = queryStartTime.plusMillis(timeZoneOffset);
+
         //Grab all night-time data for past week
-        return deviceDataDAO.getLightByBetweenHourDateByTS(accountId, deviceId, LIGHT_ON_LEVEL.intValue() , queryStartTime, queryEndTime, NIGHT_START_HOUR_LOCAL, NIGHT_END_HOUR_LOCAL);
+        return deviceDataDAO.getLightByBetweenHourDateByTS(accountId, deviceId, LIGHT_ON_LEVEL.intValue() , queryStartTime, queryEndTime, queryStartTimeLocal, queryEndTimeLocal, NIGHT_START_HOUR_LOCAL, NIGHT_END_HOUR_LOCAL);
     }
 
     private static final Optional<Integer> getTimeZoneOffsetOptional(final SleepStatsDAODynamoDB sleepStatsDAODynamoDB, final Long accountId, final DateTime queryEndDate) {


### PR DESCRIPTION
@longd3 @pims query speedup

Comparisons between new query/before query

```
=>EXPLAIN ANALYZE SELECT * FROM device_sensors_master WHERE account_id='21561' AND device_id='7600' AND ambient_light>0 AND ts>='2015-09-01 21:00:00' AND ts<='2015-09-07' AND local_utc_ts>='2015-09-01 13:00:00' AND local_utc_ts<='2015-09-07' AND(CAST(date_part('hour', local_utc_ts) AS integer)>=21 OR CAST(date_part('hour', local_utc_ts) AS integer)<1) ORDER BY ts;
--------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=68.90..68.92 rows=9 width=108) (actual time=8.802..8.952 rows=939 loops=1)
   Sort Key: device_sensors_master.ts
   Sort Method: quicksort  Memory: 157kB
   ->  Append  (cost=0.00..68.75 rows=9 width=108) (actual time=0.557..8.498 rows=939 loops=1)
         ->  Seq Scan on device_sensors_master  (cost=0.00..0.00 rows=1 width=108) (actual time=0.001..0.001 rows=0 loops=1)
               Filter: ((ambient_light > 0) AND (ts >= '2015-09-01 21:00:00'::timestamp without time zone) AND (ts <= '2015-09-07 00:00:00'::timestamp without time zone) AND (local_utc_ts >= '2015-09-01 13:00:00'::timestamp without time zone) AND (local_utc_ts <= '2015-09-07 00:00:00'::timestamp without time zone) AND (account_id = 21561::bigint) AND (device_id = 7600::bigint) AND (((date_part('hour'::text, local_utc_ts))::integer >= 21) OR ((date_part('hour'::text, local_utc_ts))::integer < 1)))
         ->  Index Scan using par_default_ts_idx on device_sensors_par_default  (cost=0.44..8.48 rows=1 width=108) (actual time=0.005..0.005 rows=0 loops=1)
               Index Cond: ((ts >= '2015-09-01 21:00:00'::timestamp without time zone) AND (ts <= '2015-09-07 00:00:00'::timestamp without time zone))
               Filter: ((ambient_light > 0) AND (local_utc_ts >= '2015-09-01 13:00:00'::timestamp without time zone) AND (local_utc_ts <= '2015-09-07 00:00:00'::timestamp without time zone) AND (account_id = 21561::bigint) AND (device_id = 7600::bigint) AND (((date_part('hour'::text, local_utc_ts))::integer >= 21) OR ((date_part('hour'::text, local_utc_ts))::integer < 1)))

=>EXPLAIN ANALYZE SELECT * FROM device_sensors_master WHERE account_id='21561' AND device_id='7600' AND ambient_light>0 AND ts>='2015-09-01 21:00:00' AND ts<='2015-09-07' AND(CAST(date_part('hour', local_utc_ts) AS integer)>=21 OR CAST(date_part('hour', local_utc_ts) AS integer)<1) ORDER BY ts;
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=918.28..918.55 rows=110 width=108) (actual time=2631.365..2631.553 rows=939 loops=1)
   Sort Key: device_sensors_master.ts
   Sort Method: quicksort  Memory: 157kB
   ->  Append  (cost=0.00..914.55 rows=110 width=108) (actual time=131.844..2630.442 rows=939 loops=1)
         ->  Seq Scan on device_sensors_master  (cost=0.00..0.00 rows=1 width=108) (actual time=0.002..0.002 rows=0 loops=1)
               Filter: ((ambient_light > 0) AND (ts >= '2015-09-01 21:00:00'::timestamp without time zone) AND (ts <= '2015-09-07 00:00:00'::timestamp without time zone) AND (account_id = 21561::bigint) AND (device_id = 7600::bigint) AND (((date_part('hour'::text, local_utc_ts))::integer >= 21) OR ((date_part('hour'::text, local_utc_ts))::integer < 1)))
         ->  Index Scan using par_default_ts_idx on device_sensors_par_default  (cost=0.44..8.48 rows=1 width=108) (actual time=0.008..0.008 rows=0 loops=1)
               Index Cond: ((ts >= '2015-09-01 21:00:00'::timestamp without time zone) AND (ts <= '2015-09-07 00:00:00'::timestamp without time zone))
```

Thanks @kingshyg - reasoning for why this works is that the `local_utc_ts` restriction limits which tables get looked at for the sorting.
