### PR TITLE
pull timezone offset with utc time, which is what sleep stats is stor…

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/Humidity.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/Humidity.java
@@ -41,7 +41,7 @@ public class Humidity {
                                                     final SleepStatsDAODynamoDB sleepStatsDAODynamoDB) {
 
 
-        final Optional<Integer> timeZoneOffsetOptional = getTimeZoneOffsetOptional(sleepStatsDAODynamoDB, accountId, DateTime.now());
+        final Optional<Integer> timeZoneOffsetOptional = getTimeZoneOffsetOptional(sleepStatsDAODynamoDB, accountId, DateTime.now(DateTimeZone.UTC));
         if (!timeZoneOffsetOptional.isPresent()) {
             LOGGER.debug("Could not get timeZoneOffset, not generating humidity insight for accountId {}", accountId);
             return Optional.absent();


### PR DESCRIPTION
…ed in

Previous misuse of local vs. utc time caused query for timezoneOffset to sometimes query a date in the future, which results in no generation of Insight
