### PR TITLE
Change in-sleep insights to use sound event count to calculate sound condition instead of using the sensor average

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -9,10 +9,10 @@ import com.hello.suripu.algorithm.utils.MotionFeatures;
 import com.hello.suripu.core.algorithmintegration.OneDaysSensorData;
 import com.hello.suripu.core.algorithmintegration.OnlineHmm;
 import com.hello.suripu.core.db.AccountDAO;
-import com.hello.suripu.core.db.FeatureExtractionModelsDAO;
 import com.hello.suripu.core.db.CalibrationDAO;
 import com.hello.suripu.core.db.DeviceDAO;
 import com.hello.suripu.core.db.DeviceDataDAO;
+import com.hello.suripu.core.db.FeatureExtractionModelsDAO;
 import com.hello.suripu.core.db.FeedbackDAO;
 import com.hello.suripu.core.db.OnlineHmmModelsDAO;
 import com.hello.suripu.core.db.RingTimeHistoryDAODynamoDB;
@@ -46,7 +46,6 @@ import com.hello.suripu.core.translations.English;
 import com.hello.suripu.core.util.AlgorithmType;
 import com.hello.suripu.core.util.DateTimeUtil;
 import com.hello.suripu.core.util.FeedbackUtils;
-import com.hello.suripu.core.util.TimelineError;
 import com.hello.suripu.core.util.MultiLightOutUtils;
 import com.hello.suripu.core.util.PartnerDataUtils;
 import com.hello.suripu.core.util.SleepHmmWithInterpretation;
@@ -62,7 +61,6 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.text.html.Option;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -705,8 +703,8 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
 
         final List<Insight> insights;
         if (hasTimelineInSleepInsights(accountId)) {
-            insights = timelineUtils.generateInSleepInsights(allSensorSampleList, sleepStats.sleepTime,
-                    sleepStats.wakeTime);
+            insights = timelineUtils.generateInSleepInsights(allSensorSampleList, numSoundEvents,
+                    sleepStats.sleepTime, sleepStats.wakeTime);
         } else {
             insights = timelineUtils.generatePreSleepInsights(allSensorSampleList,
                     sleepStats.sleepTime, accountId);

--- a/suripu-core/src/main/java/com/hello/suripu/core/util/TimelineUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/TimelineUtils.java
@@ -86,7 +86,6 @@ public class TimelineUtils {
             Sensor.TEMPERATURE,
             Sensor.HUMIDITY,
             Sensor.PARTICULATES,
-            Sensor.SOUND,
             Sensor.LIGHT,
     };
 
@@ -866,7 +865,22 @@ public class TimelineUtils {
         }
     }
 
+    public Insight generateInSleepSoundInsight(final int soundEventCount) {
+        final int soundScore = SleepScoreUtils.calculateSoundScore(soundEventCount);
+        if (soundScore <= 20) {
+            return new Insight(Sensor.SOUND, CurrentRoomState.State.Condition.ALERT,
+                    English.ALERT_SOUND_PRE_SLEEP_MESSAGE);
+        } else if (soundScore <= 60) {
+            return new Insight(Sensor.SOUND, CurrentRoomState.State.Condition.WARNING,
+                    English.WARNING_SOUND_PRE_SLEEP_MESSAGE);
+        } else {
+            return new Insight(Sensor.SOUND, CurrentRoomState.State.Condition.IDEAL,
+                    English.IDEAL_SOUND_PRE_SLEEP_MESSAGE);
+        }
+    }
+
     public List<Insight> generateInSleepInsights(final AllSensorSampleList allSensorSampleList,
+                                                 final int soundEventCount,
                                                  final Long sleepTimestampUTC,
                                                  final Long wakeTimestampUTC) {
         if (allSensorSampleList.isEmpty()) {
@@ -897,6 +911,9 @@ public class TimelineUtils {
                 insights.add(insight.get());
             }
         }
+
+        final Insight soundInsight = generateInSleepSoundInsight(soundEventCount);
+        insights.add(soundInsight);
 
         return insights;
     }

--- a/suripu-coredw/src/test/java/com/hello/suripu/coredw/util/TimelineUtilsTest.java
+++ b/suripu-coredw/src/test/java/com/hello/suripu/coredw/util/TimelineUtilsTest.java
@@ -1062,6 +1062,23 @@ public class TimelineUtilsTest extends FixtureTest {
     }
 
     @Test
+    public void generateInSleepSoundInsight() {
+        final Insight ideal = timelineUtils.generateInSleepSoundInsight(0);
+        assertThat(ideal.condition, is(equalTo(CurrentRoomState.State.Condition.IDEAL)));
+        assertThat(ideal.sensor, is(equalTo(Sensor.SOUND)));
+
+
+        final Insight warning = timelineUtils.generateInSleepSoundInsight(2);
+        assertThat(warning.condition, is(equalTo(CurrentRoomState.State.Condition.WARNING)));
+        assertThat(warning.sensor, is(equalTo(Sensor.SOUND)));
+
+
+        final Insight alert = timelineUtils.generateInSleepSoundInsight(4);
+        assertThat(alert.condition, is(equalTo(CurrentRoomState.State.Condition.ALERT)));
+        assertThat(alert.sensor, is(equalTo(Sensor.SOUND)));
+    }
+
+    @Test
     public void calculateAverageSensorStateEmptySamples() {
         final Optional<Float> average = timelineUtils.calculateAverageSensorState(Collections.<Sample>emptyList(), 0L, 10L);
         assertThat(average.isPresent(), is(false));
@@ -1099,7 +1116,7 @@ public class TimelineUtilsTest extends FixtureTest {
     @Test
     public void testGenerateInSleepInsightsMissingSensorData() {
         final AllSensorSampleList allSensorSampleList = new AllSensorSampleList();
-        final List<Insight> insights = timelineUtils.generateInSleepInsights(allSensorSampleList, 0L, 999L);
+        final List<Insight> insights = timelineUtils.generateInSleepInsights(allSensorSampleList, 0, 0L, 999L);
         assertThat(insights.isEmpty(), is(true));
     }
 
@@ -1107,7 +1124,7 @@ public class TimelineUtilsTest extends FixtureTest {
     public void testGenerateInSleepInsightsEmptyData() {
         final AllSensorSampleList allSensorSampleList = new AllSensorSampleList();
         allSensorSampleList.add(Sensor.LIGHT, Collections.<Sample>emptyList());
-        final List<Insight> insights = timelineUtils.generateInSleepInsights(allSensorSampleList, 0L, 999L);
+        final List<Insight> insights = timelineUtils.generateInSleepInsights(allSensorSampleList, 0, 0L, 999L);
         assertThat(insights.isEmpty(), is(true));
     }
 
@@ -1122,7 +1139,7 @@ public class TimelineUtilsTest extends FixtureTest {
         samples.add(new Sample(500L, 80f, 0));
         allSensorSampleList.add(Sensor.LIGHT, samples);
 
-        final List<Insight> insights = timelineUtils.generateInSleepInsights(allSensorSampleList, 10L, 100L);
+        final List<Insight> insights = timelineUtils.generateInSleepInsights(allSensorSampleList, 0, 10L, 100L);
         assertThat(insights.isEmpty(), is(false));
         assertThat(insights.get(0).condition, is(equalTo(CurrentRoomState.State.Condition.IDEAL)));
     }


### PR DESCRIPTION
As requested by @kevintwohy, this should resolve https://github.com/hello/bugs/issues/506. Reuses the score calculation from environmental scoring.
