### PR TITLE
Fix pill color retrieval for devices api v2

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/device/v2/DeviceProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/device/v2/DeviceProcessor.java
@@ -267,11 +267,11 @@ public class DeviceProcessor {
             if (!accountId.equals(senseAccountPair.accountId)) {
                 continue;
             }
-            final List<UserInfo> userInfoList = mergedUserInfoDynamoDB.getInfo(senseAccountPair.externalDeviceId);
-            if (userInfoList.isEmpty()) {
+            final Optional<UserInfo> userInfoOptional = mergedUserInfoDynamoDB.getInfo(senseAccountPair.externalDeviceId, senseAccountPair.accountId);
+            if (!userInfoOptional.isPresent()) {
                 return Optional.absent();
             }
-            final Optional<OutputProtos.SyncResponse.PillSettings> pillSettingsOptional =  userInfoList.get(0).pillColor;
+            final Optional<OutputProtos.SyncResponse.PillSettings> pillSettingsOptional =  userInfoOptional.get().pillColor;
             if (!pillSettingsOptional.isPresent()){
                 return Optional.absent();
             }

--- a/suripu-core/src/test/java/com/hello/suripu/core/db/DeviceProcessorTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/db/DeviceProcessorTest.java
@@ -84,7 +84,7 @@ public class DeviceProcessorTest {
         final OutputProtos.SyncResponse.PillSettings pillSettings = OutputProtos.SyncResponse.PillSettings.newBuilder()
                 .setPillColor(PillColorUtil.argbToIntBasedOnSystemEndianess(PillColorUtil.colorToARGB(new Color(0xFE, 0x00, 0x00)))) // Red
                 .setPillId(testPillId).build();
-        when(mergedUserInfoDynamoDB.getInfo(senseAccountPairPillColor.externalDeviceId)).thenReturn(Arrays.asList(new UserInfo(
+        when(mergedUserInfoDynamoDB.getInfo(senseAccountPairPillColor.externalDeviceId, senseAccountPairPillColor.accountId)).thenReturn(Optional.of(new UserInfo(
                         senseAccountPairPillColor.externalDeviceId,
                         senseAccountPairLastHour.accountId,
                         Collections.<Alarm>emptyList(),


### PR DESCRIPTION
- Retrieve mergerUserInfo by account id and sense external ID instead
  of just sense ID.
- Update test
- @pims review pls
