### PR TITLE
Changing feature rollout percentage to two decimal place precision

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/FirmwareUpgradePathDAO.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/FirmwareUpgradePathDAO.java
@@ -114,7 +114,7 @@ public class FirmwareUpgradePathDAO {
         for (final Map<String, AttributeValue> item : items) {
             final Integer fromFW = Integer.parseInt(item.get(FROM_FW_VERSION_ATTRIBUTE_NAME).getN());
             final Integer toFW = Integer.parseInt(item.get(TO_FW_VERSION_ATTRIBUTE_NAME).getN());
-            final Integer rolloutPercent = item.containsKey(ROLLOUT_PERCENT_ATTRIBUTE_NAME) ? Integer.parseInt(item.get(ROLLOUT_PERCENT_ATTRIBUTE_NAME).getN()) : FeatureUtils.MAX_ROLLOUT_VALUE;
+            final Float rolloutPercent = item.containsKey(ROLLOUT_PERCENT_ATTRIBUTE_NAME) ? Float.parseFloat(item.get(ROLLOUT_PERCENT_ATTRIBUTE_NAME).getN()) : FeatureUtils.MAX_ROLLOUT_VALUE;
             final UpgradeNodeRequest nodeRequest = new UpgradeNodeRequest(groupName, fromFW, toFW, rolloutPercent);
 
             upgradeNodes.add(nodeRequest);
@@ -161,7 +161,7 @@ public class FirmwareUpgradePathDAO {
     }
 
     @Timed
-    public Optional<Pair<Integer, Integer>> getNextFWVersionForGroup(final String GroupName, final Integer fromFWVersion) {
+    public Optional<Pair<Integer, Float>> getNextFWVersionForGroup(final String GroupName, final Integer fromFWVersion) {
 
         final Condition byGroupName = new Condition()
                 .withComparisonOperator(ComparisonOperator.EQ)
@@ -200,9 +200,9 @@ public class FirmwareUpgradePathDAO {
         final Map<String, AttributeValue> item = items.get(0);
         final Integer itemNextFW = Integer.parseInt(item.get(TO_FW_VERSION_ATTRIBUTE_NAME).getN());
 
-        final Integer rolloutPercent = item.containsKey(ROLLOUT_PERCENT_ATTRIBUTE_NAME) ? Integer.parseInt(item.get(ROLLOUT_PERCENT_ATTRIBUTE_NAME).getN()) : FeatureUtils.MAX_ROLLOUT_VALUE;
+        final Float rolloutPercent = item.containsKey(ROLLOUT_PERCENT_ATTRIBUTE_NAME) ? Float.parseFloat(item.get(ROLLOUT_PERCENT_ATTRIBUTE_NAME).getN()) : FeatureUtils.MAX_ROLLOUT_VALUE;
 
-        final Pair<Integer, Integer> nextFW = new Pair<>(itemNextFW, rolloutPercent);
+        final Pair<Integer, Float> nextFW = new Pair<>(itemNextFW, rolloutPercent);
         return Optional.of(nextFW);
     }
 
@@ -213,7 +213,7 @@ public class FirmwareUpgradePathDAO {
             final String groupName = item.get(GROUP_NAME_ATTRIBUTE_NAME).getS();
             final Integer fromFWVersion = Integer.valueOf(item.get(FROM_FW_VERSION_ATTRIBUTE_NAME).getN());
             final Integer newFWVersion = Integer.valueOf(item.get(TO_FW_VERSION_ATTRIBUTE_NAME).getN());
-            final Integer rolloutPercent = Integer.valueOf(item.get(ROLLOUT_PERCENT_ATTRIBUTE_NAME).getN());
+            final Float rolloutPercent = Float.valueOf(item.get(ROLLOUT_PERCENT_ATTRIBUTE_NAME).getN());
 
             return Optional.of(new UpgradeNodeRequest(groupName, fromFWVersion, newFWVersion, rolloutPercent));
         }catch (Exception ex){

--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/DynamoDBAdapter.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/DynamoDBAdapter.java
@@ -84,7 +84,6 @@ public class DynamoDBAdapter implements RolloutAdapter{
      * Checks if a user/device has the named feature enabled
      * @param feature
      * @param entityId
-     * @param hashId
      * @param groups
      * @return boolean indicating whether feature is active
      */
@@ -112,12 +111,12 @@ public class DynamoDBAdapter implements RolloutAdapter{
             }
         }
 
-        if(feature.percentage == 0) {
-            LOGGER.trace("Percentage is 0, turning off for everyone");
+        if(feature.percentage == 0.0f) {
+            LOGGER.trace("Percentage is 0.0, turning off for everyone");
             return false;
         }
 
-        if (FeatureUtils.entityIdHashInPercentRange(entityId, 0, feature.percentage)) {
+        if (FeatureUtils.entityIdHashInPercentRange(entityId, 0.0f, feature.percentage)) {
             LOGGER.trace("Included in percentage.");
             return true;
         }

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Feature.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Feature.java
@@ -27,14 +27,14 @@ public class Feature implements Comparable<Feature> {
     public final Set<String> groups;
 
     @JsonProperty("percentage")
-    public final Integer percentage;
+    public final Float percentage;
 
     @JsonCreator
     public Feature(
             @JsonProperty("name") final String name,
             @JsonProperty("ids") final Collection<String> ids,
             @JsonProperty("groups") final Collection<String> groups,
-            @JsonProperty("percentage") final Integer percentage) {
+            @JsonProperty("percentage") final Float percentage) {
         this.name = name.trim();
         this.ids = ImmutableSet.copyOf(trimStringsInCollection(ids));
         this.groups = ImmutableSet.copyOf(trimStringsInCollection(groups));
@@ -82,7 +82,7 @@ public class Feature implements Comparable<Feature> {
 
         final List<String> groups = Arrays.asList(splitResult[2].split(","));
         final List<String> userIds = Arrays.asList(splitResult[1].split(","));
-        final int percentage = Integer.parseInt(splitResult[0]);
+        final Float percentage = Float.parseFloat(splitResult[0]);
         return new Feature(featureName, userIds, groups, percentage);
     }
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/UpgradeNodeRequest.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/UpgradeNodeRequest.java
@@ -19,14 +19,14 @@ public class UpgradeNodeRequest {
     @NotNull
     public final Integer toFWVersion;
 
-    public final Integer rolloutPercent;
+    public final Float rolloutPercent;
 
     @JsonCreator
     public UpgradeNodeRequest(
             @JsonProperty("group_name") final String groupName,
             @JsonProperty("from_fw_version") final Integer fromFWVersion,
             @JsonProperty("to_fw_version") final Integer toFWVersion,
-            @JsonProperty("rollout_percent") final Integer rolloutPercent) {
+            @JsonProperty("rollout_percent") final Float rolloutPercent) {
 
         this.groupName = groupName;
         this.fromFWVersion = fromFWVersion;

--- a/suripu-core/src/main/java/com/hello/suripu/core/util/FeatureUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/FeatureUtils.java
@@ -8,10 +8,10 @@ import org.slf4j.LoggerFactory;
  */
 public class FeatureUtils {
 
-    public static final Integer MAX_ROLLOUT_VALUE = 100;
+    public static final Float MAX_ROLLOUT_VALUE = 100.00f;
     private static final Logger LOGGER = LoggerFactory.getLogger(FeatureUtils.class);
 
-    public static Boolean entityIdHashInPercentRange(final String entityId, final Integer startRange, final Integer endRange) {
+    public static Boolean entityIdHashInPercentRange(final String entityId, final Float startRange, final Float endRange) {
 
         if (startRange > endRange) {
             LOGGER.error("Invalid range parameters.");
@@ -22,7 +22,7 @@ public class FeatureUtils {
             return false;
         }
 
-        final Integer remainder = Math.abs(entityId.hashCode()) % MAX_ROLLOUT_VALUE;
-        return ((startRange <= remainder) && (remainder < endRange));
+        final Float entityPercent = (Math.abs(entityId.hashCode()) % (MAX_ROLLOUT_VALUE * 100.00f) / 100.0f);
+        return ((startRange <= entityPercent) && (entityPercent <= endRange));
     }
 }

--- a/suripu-core/src/test/java/com/hello/suripu/core/flipper/FeatureFlipperTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/flipper/FeatureFlipperTest.java
@@ -23,10 +23,10 @@ public class FeatureFlipperTest {
         final List<String> devices = Lists.newArrayList("fake-sense1","fake-sense2");
         final List<String> featureGroups = Lists.newArrayList("group1","group2");
         final List<String> allGroups = Lists.newArrayList("all");
-        final Feature feature = new Feature("test_feature", devices, featureGroups, 10);
-        final Feature allGroupsfeature = new Feature("test_feature", devices, allGroups, 10);
-        final String goodDevice = "a51cd929-15e9-483d-a504-e3b28dde4fd5";
-        final String badDevice = "b5b776cd-843d-4b10-8db5-e4c75d217beb";
+        final Feature feature = new Feature("test_feature", devices, featureGroups, 10.0f);
+        final Feature allGroupsFeature = new Feature("test_feature", devices, allGroups, 10.0f);
+        final String goodDevice = "8d22f09f-e28c-4883-9a44-0b36c0b51fcd";
+        final String badDevice = "49e807dd-f848-4970-80df-dcb6cfbd54a7";
         final List<String> matchDeviceGroups = Lists.newArrayList("group1");
         final List<String> noMatchDeviceGroups = Lists.newArrayList("another-group");
         final List<String> noDeviceGroups = Lists.newArrayList();
@@ -37,8 +37,8 @@ public class FeatureFlipperTest {
         assertThat(DynamoDBAdapter.featureActive(feature, badDevice, noMatchDeviceGroups), is(false));
         assertThat(DynamoDBAdapter.featureActive(feature, goodDevice, noDeviceGroups), is(true));
         assertThat(DynamoDBAdapter.featureActive(feature, badDevice, noDeviceGroups), is(false));
-        assertThat(DynamoDBAdapter.featureActive(allGroupsfeature, goodDevice, noDeviceGroups), is(true));
-        assertThat(DynamoDBAdapter.featureActive(allGroupsfeature, badDevice, noDeviceGroups), is(true));
+        assertThat(DynamoDBAdapter.featureActive(allGroupsFeature, goodDevice, noDeviceGroups), is(true));
+        assertThat(DynamoDBAdapter.featureActive(allGroupsFeature, badDevice, noDeviceGroups), is(true));
     }
 
     @Test
@@ -46,27 +46,28 @@ public class FeatureFlipperTest {
         final List<String> accountIds = Lists.newArrayList();
         while ( accountIds.size() < FeatureUtils.MAX_ROLLOUT_VALUE) {
             final String uuid = UUID.randomUUID().toString();
-            final Integer hash = Math.abs(uuid.hashCode()) % FeatureUtils.MAX_ROLLOUT_VALUE;
-            if (hash.equals(accountIds.size())) {
+            final Float hash = (Math.abs(uuid.hashCode()) % (FeatureUtils.MAX_ROLLOUT_VALUE * 100.00f) / 100.0f);
+            if ((accountIds.size() + 1) > hash && hash > accountIds.size()) {
                 accountIds.add(uuid);
             }
         }
-        final Integer percentage = 40;
+        final Float percentage = 40.0f;
         final List<String> correctIds = new ArrayList<>();
         for (final String deviceId : accountIds) {
-            if (FeatureUtils.entityIdHashInPercentRange(deviceId, 0, percentage)) {
+            if (FeatureUtils.entityIdHashInPercentRange(deviceId, 0.0f, percentage)) {
                 correctIds.add(deviceId);
             }
         }
-        assertThat(correctIds.size(), is(percentage));
+        assertThat(correctIds.size(), is(percentage.intValue()));
 
         correctIds.clear();
         for (final String deviceId : accountIds) {
-            if (FeatureUtils.entityIdHashInPercentRange(deviceId, 30, percentage)) {
+            if (FeatureUtils.entityIdHashInPercentRange(deviceId, 30.0f, percentage)) {
                 correctIds.add(deviceId);
             }
         }
-        assertThat(correctIds.size(), is(percentage - 30));
+        final Integer subSet = percentage.intValue() - 30;
+        assertThat(correctIds.size(), is(subSet));
     }
 }
 


### PR DESCRIPTION
This is to give us finer-grained control over the rollouts as customer base increases. Currently, the smallest unit we have for rollout is 1% @ ~13,000 active devices.

@pims Review, please.  
