### PR TITLE
Move last seen saving to SenseLastSeenProcessor

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/cli/CreateDynamoDBTables.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/cli/CreateDynamoDBTables.java
@@ -24,6 +24,7 @@ import com.hello.suripu.core.db.OnlineHmmModelsDAODynamoDB;
 import com.hello.suripu.core.db.ResponseCommandsDAODynamoDB;
 import com.hello.suripu.core.db.RingTimeHistoryDAODynamoDB;
 import com.hello.suripu.core.db.ScheduledRingTimeHistoryDAODynamoDB;
+import com.hello.suripu.core.db.SensorsViewsDynamoDB;
 import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
 import com.hello.suripu.core.db.SmartAlarmLoggerDynamoDB;
 import com.hello.suripu.core.db.TeamStore;
@@ -78,6 +79,7 @@ public class CreateDynamoDBTables extends ConfiguredCommand<SuripuAppConfigurati
         createWifiInfoTable(configuration, awsCredentialsProvider);
         createAppStatsTable(configuration, awsCredentialsProvider);
         createPillHeartBeatTable(configuration, awsCredentialsProvider);
+        createLastSeenTable(configuration, awsCredentialsProvider);
     }
 
     private void createSmartAlarmLogTable(final SuripuAppConfiguration configuration, final AWSCredentialsProvider awsCredentialsProvider){
@@ -534,6 +536,22 @@ public class CreateDynamoDBTables extends ConfiguredCommand<SuripuAppConfigurati
             System.out.println(String.format("%s already exists.", tableName));
         } catch (AmazonServiceException exception) {
             final CreateTableResult result = DeviceDataDAODynamoDB.createTable(tableName, client);
+            final TableDescription description = result.getTableDescription();
+            System.out.println(description.getTableStatus());
+        }
+    }
+
+    private void createLastSeenTable(final SuripuAppConfiguration configuration, final AWSCredentialsProvider awsCredentialsProvider) {
+        final AmazonDynamoDBClient client = new AmazonDynamoDBClient(awsCredentialsProvider);
+        final DynamoDBConfiguration config = configuration.getSenseLastSeenConfiguration();
+        final String tableName = config.getTableName();
+        client.setEndpoint(config.getEndpoint());
+
+        try {
+            client.describeTable(tableName);
+            System.out.println(String.format("%s already exists.", tableName));
+        } catch (AmazonServiceException exception) {
+            final CreateTableResult result = SensorsViewsDynamoDB.createLastSeenTable(tableName, client);
             final TableDescription description = result.getTableDescription();
             System.out.println(description.getTableStatus());
         }

--- a/suripu-core/src/main/java/com/hello/suripu/core/db/SensorsViewsDynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/SensorsViewsDynamoDB.java
@@ -95,7 +95,6 @@ public class SensorsViewsDynamoDB {
 
         items.put(FIRMWARE_VERSION_ATTRIBUTE_NAME, new AttributeValue().withN(String.valueOf(deviceData.firmwareVersion)));
         items.put(UPDATED_AT_UTC_ATTRIBUTE_NAME, new AttributeValue().withS(deviceData.dateTimeUTC.toString(DATETIME_FORMAT)));
-        items.put(TZ_OFFSET_ATTRIBUTE_NAME, new AttributeValue().withN(String.valueOf(deviceData.offsetMillis)));
 
         final PutRequest putRequest = new PutRequest(items);
         return new WriteRequest(putRequest);

--- a/suripu-workers/configs/sense/sense_last_seen.dev.yml.example
+++ b/suripu-workers/configs/sense/sense_last_seen.dev.yml.example
@@ -27,8 +27,10 @@ dynamodb:
   tables:
     features: features
     wifi_info: wifi_info
+    sense_last_seen: sense_last_seen
 
   endpoints:
     features: http://localhost:7777
     wifi_info: http://localhost:7777
+    sense_last_seen: http://localhost:7777
 

--- a/suripu-workers/configs/sense/sense_last_seen.prod.yml
+++ b/suripu-workers/configs/sense/sense_last_seen.prod.yml
@@ -47,8 +47,10 @@ dynamodb:
   tables:
     features: features
     wifi_info: prod_wifi_info
+    sense_last_seen: prod_sense_last_seen
 
   endpoints:
     features: http://dynamodb.us-east-1.amazonaws.com
     wifi_info: http://dynamodb.us-east-1.amazonaws.com
+    sense_last_seen: http://dynamodb.us-east-1.amazonaws.com
 

--- a/suripu-workers/configs/sense/sense_last_seen.staging.yml
+++ b/suripu-workers/configs/sense/sense_last_seen.staging.yml
@@ -27,8 +27,10 @@ dynamodb:
   tables:
     features: features
     wifi_info: wifi_info
+    sense_last_seen: sense_last_seen
 
   endpoints:
     features: http://dynamodb.us-east-1.amazonaws.com
     wifi_info: http://dynamodb.us-east-1.amazonaws.com
+    sense_last_seen: http://dynamodb.us-east-1.amazonaws.com
 

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/sense/SenseProcessorUtils.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/sense/SenseProcessorUtils.java
@@ -1,0 +1,38 @@
+package com.hello.suripu.workers.sense;
+
+
+import com.hello.suripu.api.input.DataInputProtos;
+import com.hello.suripu.core.util.DateTimeUtil;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public class SenseProcessorUtils {
+    public final static Integer CLOCK_SKEW_TOLERATED_IN_HOURS = 2;
+
+    public static DateTime getSampleTime(final DateTime createdAtRounded, final DataInputProtos.periodic_data periodicData, final Boolean attemptToRecoverSenseReportedTimeStamp) {
+        // To validate that the firmware is sending a correct unix timestamp
+        // we need to compare it to something immutable, coming from a different clock (server)
+        // We can't compare to now because now changes, and if we want to reprocess old data it will be immediately discarded
+
+        final Long timestampMillis = periodicData.getUnixTime() * 1000L;
+        final DateTime rawDateTime = new DateTime(timestampMillis, DateTimeZone.UTC).withSecondOfMinute(0).withMillisOfSecond(0);
+
+        // This is intended to check for very specific clock bugs from Sense
+        final DateTime periodicDataSampleDateTime = attemptToRecoverSenseReportedTimeStamp
+                ? DateTimeUtil.possiblySanitizeSampleTime(createdAtRounded, rawDateTime, CLOCK_SKEW_TOLERATED_IN_HOURS)
+                : rawDateTime;
+        return periodicDataSampleDateTime;
+    }
+
+    public static Boolean isClockOutOfSync(final DateTime sampleDateTime, final DateTime createdAtRounded) {
+        return sampleDateTime.isAfter(createdAtRounded.plusHours(CLOCK_SKEW_TOLERATED_IN_HOURS)) || sampleDateTime.isBefore(createdAtRounded.minusHours(CLOCK_SKEW_TOLERATED_IN_HOURS));
+    }
+
+    public static Integer getFirmwareVersion(final DataInputProtos.BatchPeriodicDataWorker batchPeriodicDataWorker, final DataInputProtos.periodic_data periodicData) {
+        // Grab FW version from Batch or periodic data for EVT units
+        final Integer firmwareVersion =  batchPeriodicDataWorker.getData().hasFirmwareVersion()
+                ? batchPeriodicDataWorker.getData().getFirmwareVersion()
+                : periodicData.getFirmwareVersion();
+        return firmwareVersion;
+    }
+}

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/sense/lastSeen/SenseLastSeenProcessorFactory.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/sense/lastSeen/SenseLastSeenProcessorFactory.java
@@ -2,22 +2,25 @@ package com.hello.suripu.workers.sense.lastSeen;
 
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
+import com.hello.suripu.core.db.SensorsViewsDynamoDB;
 import com.hello.suripu.core.db.WifiInfoDAO;
 
 public class SenseLastSeenProcessorFactory implements IRecordProcessorFactory {
     private final Integer maxRecords;
     private final WifiInfoDAO wifiInfoDAO;
+    private final SensorsViewsDynamoDB sensorsViewsDynamoDB;
 
-    public SenseLastSeenProcessorFactory(
-            final Integer maxRecords,
-            final WifiInfoDAO wifiInfoDAO) {
+    public SenseLastSeenProcessorFactory(final Integer maxRecords,
+                                         final WifiInfoDAO wifiInfoDAO,
+                                         final SensorsViewsDynamoDB sensorsViewsDynamoDB){
+
         this.maxRecords = maxRecords;
         this.wifiInfoDAO = wifiInfoDAO;
-
+        this.sensorsViewsDynamoDB = sensorsViewsDynamoDB;
     }
 
     @Override
     public IRecordProcessor createProcessor() {
-        return new SenseLastSeenProcessor(maxRecords, wifiInfoDAO);
+        return new SenseLastSeenProcessor(maxRecords, wifiInfoDAO, sensorsViewsDynamoDB);
     }
 }


### PR DESCRIPTION
- Tested locally with dev stream
- Add missing table creation command
- Move shared methods to new class SenseProcessorUtils
- Leave SenseSaveProcessor almost untouched (as we can turn off last seen task there by flip feature off) except for the refactoring common functions

@pims 
