### PR TITLE
Fix bad offset computation when crossing DST boundaries

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Alarm.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Alarm.java
@@ -420,12 +420,11 @@ public class Alarm {
                 if(alarm.isRepeated){
                     for(final Integer dayOfWeek:alarm.dayOfWeek){
                         int dayDifference = dayOfWeek - currentLocalTime.getDayOfWeek();
-                        DateTime ringTime = currentLocalTime.withTimeAtStartOfDay().plusDays(dayDifference).plusHours(alarm.hourOfDay).plusMinutes(alarm.minuteOfHour);
+                        DateTime ringTime = currentLocalTime.withTimeAtStartOfDay().plusDays(dayDifference).withHourOfDay(alarm.hourOfDay).withMinuteOfHour(alarm.minuteOfHour);
                         if(ringTime.isBefore(currentLocalTime)){
                             // this alarm should be in next week.
                             ringTime = ringTime.plusWeeks(1);
                         }
-
                         possibleRings.add(new RingTime(ringTime.getMillis(), ringTime.getMillis(), alarm.sound.id, alarm.isSmart));
                     }
                 }else{


### PR DESCRIPTION
:warning: effin' :watch: 

Some users have complained about the alarm ringing earlier than expected on the first day after DST changes.

the culprit seems to be the `plusHours(6)` as opposed to `withHour(6)`.
I've added tests that mimic the next DST changes.

Would appreciate careful review of the tests. Thanks!

cc @jnorgan @kingshyg @jakepic1 
