### PR TITLE
Attempt to reduce sense last seen write request

### DIFF
--- a/suripu-workers/src/main/java/com/hello/suripu/workers/sense/lastSeen/SenseLastSeenProcessor.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/sense/lastSeen/SenseLastSeenProcessor.java
@@ -70,12 +70,12 @@ public class SenseLastSeenProcessor extends HelloBaseRecordProcessor {
 
     @Override
     public void initialize(String s) {
-        shardId = s;
+        this.shardId = s;
         createNewBloomFilter();
     }
 
     private void createNewBloomFilter() {
-        bloomFilter = BloomFilter.create(Funnels.stringFunnel(), BLOOM_FILTER_CAPACITY, BLOOM_FILTER_ERROR_RATE);
+        this.bloomFilter = BloomFilter.create(Funnels.stringFunnel(), BLOOM_FILTER_CAPACITY, BLOOM_FILTER_ERROR_RATE);
         this.lastBloomFilterCreated = DateTime.now(DateTimeZone.UTC);
     }
 


### PR DESCRIPTION
- At the moment, we persist every sensor data taken from kinesis stream into last seen table and realize that we can be more economic about it. 
- This PR attempts to skip writing last seen for recently seen sense which have no interaction
- @pims pls review 
