### PR TITLE
Use separate feature flipper for DDB Device Data for Timeline

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -24,6 +24,7 @@ public class FeatureFlipper {
     public final static String DELAY_CURRENT_ROOM_STATE_THRESHOLD = "delay_current_room_state_threshold";
     public final static String DUST_SMOOTH = "dust_smooth";
     public final static String DYNAMODB_DEVICE_DATA = "dynamodb_device_data";
+    public final static String DYNAMODB_DEVICE_DATA_TIMELINE = "dynamodb_device_data_timeline";
 
     public final static String ENABLE_OTA_UPDATES = "enable_ota_updates";
     public final static String ENVIRONMENT_IN_TIMELINE_SCORE = "environment_in_timeline_score";

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/FeatureFlippedProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/FeatureFlippedProcessor.java
@@ -106,7 +106,7 @@ public class FeatureFlippedProcessor {
         return featureFlipper.userFeatureActive(FeatureFlipper.SENSORS_DB_UNAVAILABLE, accountId, Collections.EMPTY_LIST);
     }
 
-    protected Boolean hasDeviceDataDynamoDBEnabled(final long accountId) {
-        return featureFlipper.userFeatureActive(FeatureFlipper.DYNAMODB_DEVICE_DATA, accountId, Collections.EMPTY_LIST);
+    protected Boolean hasDeviceDataDynamoDBTimelineEnabled(final long accountId) {
+        return featureFlipper.userFeatureActive(FeatureFlipper.DYNAMODB_DEVICE_DATA_TIMELINE, accountId, Collections.EMPTY_LIST);
     }
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -485,7 +485,7 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
             // query dates in utc_ts (table has an index for this)
             LOGGER.debug("Query all sensors with utc ts for account {}", accountId);
 
-            if (hasDeviceDataDynamoDBEnabled(accountId)) {
+            if (hasDeviceDataDynamoDBTimelineEnabled(accountId)) {
                 allSensorSampleList = deviceDataDAODynamoDB.generateTimeSeriesByUTCTimeAllSensors(
                         targetDate.minusMillis(tzOffsetMillis).getMillis(),
                         endDate.minusMillis(tzOffsetMillis).getMillis(),


### PR DESCRIPTION
Because we don't have enough data backfilled yet, this is so we can turn on DDB device data for the sensor / roomconditions endpoints but not the timeline yet.

cc @pims 
