### PR TITLE
Fix broken ReceiveResource test

### DIFF
--- a/suripu-service/src/test/java/com/hello/suripu/service/resources/ReceiveResourceTest.java
+++ b/suripu-service/src/test/java/com/hello/suripu/service/resources/ReceiveResourceTest.java
@@ -85,7 +85,6 @@ public class ReceiveResourceTest {
 
     @Test
     public void testComputeNextUploadIntervalRandomNow(){
-
         final Random random = new Random(DateTime.now().getMillis());
 
         for(int i = 1; i < DateTimeConstants.MINUTES_PER_DAY; i++) {
@@ -95,7 +94,8 @@ public class ReceiveResourceTest {
             final DateTime current = new DateTime(random.nextLong());
             final RingTime nextRingTime = new RingTime(actualRingTime, actualRingTime, new long[0], false);
             final int uploadCycle = ReceiveResource.computeNextUploadInterval(nextRingTime, current, senseUploadConfiguration, false);
-            assertThat(uploadCycle <= senseUploadConfiguration.getDefaultUploadInterval(), is(true));
+            // Next interval should never be > the maximum interval (increased non peak)
+            assertThat(uploadCycle <= senseUploadConfiguration.getIncreasedNonPeakUploadInterval(), is(true));
         }
     }
 


### PR DESCRIPTION
This test was failing, since it will sometimes generate a `current` date during non-peak times.
