### PR TITLE
Changing maxIdleTime to not last forever-ish

### DIFF
--- a/suripu-service/suripu-service.prod.yml
+++ b/suripu-service/suripu-service.prod.yml
@@ -103,6 +103,7 @@ logging:
 http:
     port: 5555
     adminPort: 5556
+    maxIdleTime: 25s
     # HTTP request log settings.
     requestLog:
       file:

--- a/suripu-service/suripu-service.staging.yml
+++ b/suripu-service/suripu-service.staging.yml
@@ -104,6 +104,7 @@ http:
   port: 5555
   adminPort: 5556
   minThreads: 2
+  maxIdleTime: 25s
   # HTTP request log settings.
   requestLog:
     file:


### PR DESCRIPTION
cc @jakepic1 

This bounds the time a request stays idle when a sense most likely stopped reading on that socket.
