### PR TITLE
Initial work to add images to insight cards for the next version of the mobile clients

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/InsightCard.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/InsightCard.java
@@ -119,8 +119,8 @@ public class InsightCard implements Comparable<InsightCard> {
     @JsonProperty("info_preview")
     public final Optional<String> infoPreview;
 
-    @JsonProperty("multi_density_image")
-    public final Optional<MultiDensityImage> multiDensityImage;
+    @JsonProperty("image")
+    public final Optional<MultiDensityImage> image;
 
     public InsightCard(final Long accountId, final String title, final String message,
                        final Category category, final TimePeriod timePeriod, final DateTime timestamp) {
@@ -129,7 +129,7 @@ public class InsightCard implements Comparable<InsightCard> {
 
     public InsightCard(final Long accountId, final String title, final String message,
                        final Category category, final TimePeriod timePeriod, final DateTime timestamp,
-                       final Optional<String> infoPreview, final Optional<MultiDensityImage> multiDensityImage) {
+                       final Optional<String> infoPreview, final Optional<MultiDensityImage> image) {
         this.accountId = Optional.fromNullable(accountId);
         this.title = title;
         this.message = message;
@@ -137,7 +137,7 @@ public class InsightCard implements Comparable<InsightCard> {
         this.timePeriod = timePeriod;
         this.timestamp = timestamp;
         this.infoPreview = infoPreview;
-        this.multiDensityImage = multiDensityImage;
+        this.image = image;
     }
 
     @Override
@@ -162,7 +162,7 @@ public class InsightCard implements Comparable<InsightCard> {
                 this.timePeriod,
                 this.timestamp,
                 infoPreview,
-                this.multiDensityImage);
+                this.image);
     }
 
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/MultiDensityImage.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/MultiDensityImage.java
@@ -7,20 +7,20 @@ import com.google.common.base.Optional;
  * Created by km on 11/18/15.
  */
 public class MultiDensityImage {
-    @JsonProperty("1x")
-    public final Optional<String> normalDensity;
+    @JsonProperty("phone_1x")
+    public final Optional<String> phoneDensityNormal;
 
-    @JsonProperty("2x")
-    public final Optional<String> highDensity;
+    @JsonProperty("phone_2x")
+    public final Optional<String> phoneDensityHigh;
 
-    @JsonProperty("3x")
-    public final Optional<String> extraHighDensity;
+    @JsonProperty("phone_3x")
+    public final Optional<String> phoneDensityExtraHigh;
 
-    public MultiDensityImage(@JsonProperty("1x") final Optional<String> normalDensity,
-                             @JsonProperty("2x") final Optional<String> highDensity,
-                             @JsonProperty("3x") final Optional<String> extraHighDensity) {
-        this.normalDensity = normalDensity;
-        this.highDensity = highDensity;
-        this.extraHighDensity = extraHighDensity;
+    public MultiDensityImage(@JsonProperty("phone_1x") final Optional<String> phoneDensityNormal,
+                             @JsonProperty("phone_2x") final Optional<String> phoneDensityHigh,
+                             @JsonProperty("phone_3x") final Optional<String> phoneDensityExtraHigh) {
+        this.phoneDensityNormal = phoneDensityNormal;
+        this.phoneDensityHigh = phoneDensityHigh;
+        this.phoneDensityExtraHigh = phoneDensityExtraHigh;
     }
 }

--- a/suripu-core/src/test/java/com/hello/suripu/core/db/InsightsDAODynamoDBIT.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/db/InsightsDAODynamoDBIT.java
@@ -102,9 +102,9 @@ public class InsightsDAODynamoDBIT {
         final List<InsightCard> insightsReverseChronological = insightsDAODynamoDB.getInsightsByDate(accountId, DateTime.parse("2015-05-07T23:17:25.162Z"), false, limit);
         assertThat(insightsReverseChronological.size(), is(limit));
         assertThat(insightsReverseChronological.get(0).timestamp, is(DateTime.parse("2015-05-06T23:17:25.162Z")));
-        assertThat(insightsReverseChronological.get(0).multiDensityImage.isPresent(), is(false));
+        assertThat(insightsReverseChronological.get(0).image.isPresent(), is(false));
         assertThat(insightsReverseChronological.get(2).timestamp, is(DateTime.parse("2015-05-04T20:17:25.162Z")));
-        assertThat(insightsReverseChronological.get(2).multiDensityImage.isPresent(), is(false));
+        assertThat(insightsReverseChronological.get(2).image.isPresent(), is(false));
 
         // Chronological order
         final List<InsightCard> insightsChronological = insightsDAODynamoDB.getInsightsByDate(accountId, DateTime.parse("2012-01-01T00:00:25.162Z"), true, limit);
@@ -114,9 +114,9 @@ public class InsightsDAODynamoDBIT {
             LOGGER.debug(card.timestamp.toString());
         }
         assertThat(insightsChronological.get(0).timestamp, is(DateTime.parse("2015-05-04T20:17:25.162Z")));
-        assertThat(insightsChronological.get(0).multiDensityImage.isPresent(), is(false));
+        assertThat(insightsChronological.get(0).image.isPresent(), is(false));
         assertThat(insightsChronological.get(3).timestamp, is(DateTime.parse("2015-05-01T01:17:25.162Z")));
-        assertThat(insightsChronological.get(3).multiDensityImage.isPresent(), is(false));
+        assertThat(insightsChronological.get(3).image.isPresent(), is(false));
     }
 
     @Test
@@ -141,28 +141,28 @@ public class InsightsDAODynamoDBIT {
         assertThat(insights.size(), is(equalTo(2)));
 
         final InsightCard withCompleteImage = insights.get(0);
-        assertThat(withCompleteImage.multiDensityImage.isPresent(), is(true));
+        assertThat(withCompleteImage.image.isPresent(), is(true));
 
-        final MultiDensityImage fromDbCompleteImage = withCompleteImage.multiDensityImage.get();
-        assertThat(fromDbCompleteImage.normalDensity.isPresent(), is(true));
-        assertThat(fromDbCompleteImage.normalDensity, is(equalTo(completeImage.normalDensity)));
+        final MultiDensityImage fromDbCompleteImage = withCompleteImage.image.get();
+        assertThat(fromDbCompleteImage.phoneDensityNormal.isPresent(), is(true));
+        assertThat(fromDbCompleteImage.phoneDensityNormal, is(equalTo(completeImage.phoneDensityNormal)));
 
-        assertThat(fromDbCompleteImage.highDensity.isPresent(), is(true));
-        assertThat(fromDbCompleteImage.highDensity, is(equalTo(completeImage.highDensity)));
+        assertThat(fromDbCompleteImage.phoneDensityHigh.isPresent(), is(true));
+        assertThat(fromDbCompleteImage.phoneDensityHigh, is(equalTo(completeImage.phoneDensityHigh)));
 
-        assertThat(fromDbCompleteImage.extraHighDensity.isPresent(), is(true));
-        assertThat(fromDbCompleteImage.extraHighDensity, is(equalTo(completeImage.extraHighDensity)));
+        assertThat(fromDbCompleteImage.phoneDensityExtraHigh.isPresent(), is(true));
+        assertThat(fromDbCompleteImage.phoneDensityExtraHigh, is(equalTo(completeImage.phoneDensityExtraHigh)));
 
         final InsightCard withIncompleteImage = insights.get(1);
-        assertThat(withIncompleteImage.multiDensityImage.isPresent(), is(true));
+        assertThat(withIncompleteImage.image.isPresent(), is(true));
 
-        final MultiDensityImage fromDbIncompleteImage = withIncompleteImage.multiDensityImage.get();
-        assertThat(fromDbIncompleteImage.normalDensity.isPresent(), is(true));
-        assertThat(fromDbIncompleteImage.normalDensity, is(equalTo(completeImage.normalDensity)));
+        final MultiDensityImage fromDbIncompleteImage = withIncompleteImage.image.get();
+        assertThat(fromDbIncompleteImage.phoneDensityNormal.isPresent(), is(true));
+        assertThat(fromDbIncompleteImage.phoneDensityNormal, is(equalTo(completeImage.phoneDensityNormal)));
 
-        assertThat(fromDbIncompleteImage.highDensity.isPresent(), is(false));
+        assertThat(fromDbIncompleteImage.phoneDensityHigh.isPresent(), is(false));
 
-        assertThat(fromDbIncompleteImage.extraHighDensity.isPresent(), is(true));
-        assertThat(fromDbIncompleteImage.extraHighDensity, is(equalTo(completeImage.extraHighDensity)));
+        assertThat(fromDbIncompleteImage.phoneDensityExtraHigh.isPresent(), is(true));
+        assertThat(fromDbIncompleteImage.phoneDensityExtraHigh, is(equalTo(completeImage.phoneDensityExtraHigh)));
     }
 }


### PR DESCRIPTION
# Questions
- Where are the images going to live – probably S3?
- How much do we care about supporting future size classes (tablet, web)?
- Do we care about having larger images attached to the `InfoInsightCards`? Based on the design work I saw yesterday, we can probably use the image from the `InsightCard` in the scaled up UI, and effectively deprecate the `image_url` field
- Would it be useful to store the image size in points and include that in the API response? something like `"phone_width": 300, "phone_height": 200`

---
# Rules for choosing images
- Determine size class for device – currently always `phone`
- Determine screen density (e.g. 1x/mdpi, 2x/xhdpi, 3x/xxhdpi)
- Round fractional screen densities up to the next whole number (e.g. 1.5x/hdpi -> 2x/xhdpi)
- Constrain max density to 3x/xxhdpi
- Combine size class and density to look up correct image (e.g. `phone_2x`)

---
# Caching

To reduce overhead, when the images are served they should include either an Etag or creation/modified date headers. The clients should honor these headers.
