### PR TITLE
Throwing HTTP 408 for TimeoutExceptions

### DIFF
--- a/suripu-coredw8/src/main/java/com/hello/suripu/coredw8/util/CustomJSONExceptionMapper.java
+++ b/suripu-coredw8/src/main/java/com/hello/suripu/coredw8/util/CustomJSONExceptionMapper.java
@@ -1,6 +1,9 @@
 package com.hello.suripu.coredw8.util;
 
 import com.hello.suripu.core.util.JsonError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -8,8 +11,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.concurrent.TimeoutException;
 
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
@@ -66,6 +68,15 @@ public class CustomJSONExceptionMapper implements ExceptionMapper<Throwable> {
             if (throwable.getClass().getName().startsWith("com.sun.jersey.api")) {
 //                    final String message = throwable.
                 LOGGER.error("{}", throwable);
+            }
+
+            // To not confuse Timeout exceptions from ELB with real 500s
+            // let's catch them and return a blank response
+            if(throwable instanceof TimeoutException) {
+                return Response.status(Response.Status.REQUEST_TIMEOUT)
+                        .entity("")
+                        .type(MediaType.TEXT_PLAIN_TYPE)
+                        .build();
             }
 
             // Use the default


### PR DESCRIPTION
Goal is to catch TimeoutExceptions and have them disambiguated from HTTP_5XX to not trigger Cloudwatch Alerts – or trigger a different one with a higher tolerance.
