### PR TITLE
Remove yammer metrics from DeviceDataDAODynamoDB

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDataDAODynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDataDAODynamoDB.java
@@ -370,9 +370,7 @@ public class DeviceDataDAODynamoDB extends TimeSeriesDAODynamoDB<DeviceData> imp
             }
         }
 
-        final List<DeviceData> aggregated;
-
-        aggregated = aggregateDynamoDBItemsToDeviceData(filteredResults, slotDuration);
+        final List<DeviceData> aggregated = aggregateDynamoDBItemsToDeviceData(filteredResults, slotDuration);
 
         return new DeviceDataResponse(ImmutableList.copyOf(aggregated), results.status, results.exception);
     }


### PR DESCRIPTION
@jakepic1 : as discussed, because yammer metrics are incompatible with
other resources based-on DW 0.8
