### PR TITLE
Move SenseProcessorUtils to suripu.core so it can be used from Firehose

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/SenseProcessorUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/SenseProcessorUtils.java
@@ -1,4 +1,4 @@
-package com.hello.suripu.workers.sense;
+package com.hello.suripu.core.util;
 
 
 import com.amazonaws.AmazonClientException;
@@ -7,7 +7,6 @@ import com.hello.suripu.api.input.DataInputProtos;
 import com.hello.suripu.core.db.MergedUserInfoDynamoDB;
 import com.hello.suripu.core.models.DeviceData;
 import com.hello.suripu.core.models.UserInfo;
-import com.hello.suripu.core.util.DateTimeUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;

--- a/suripu-core/src/test/java/com/hello/suripu/core/util/SenseProcessorUtilsTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/SenseProcessorUtilsTest.java
@@ -1,4 +1,4 @@
-package com.hello.suripu.workers.sense;
+package com.hello.suripu.core.util;
 
 import com.hello.suripu.api.input.DataInputProtos;
 import com.hello.suripu.core.models.DeviceData;

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/sense/SenseSaveDDBProcessor.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/sense/SenseSaveDDBProcessor.java
@@ -1,23 +1,18 @@
 package com.hello.suripu.workers.sense;
 
-import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.InvalidStateException;
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
 import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason;
 import com.amazonaws.services.kinesis.model.Record;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hello.suripu.api.input.DataInputProtos;
-import com.hello.suripu.core.ObjectGraphRoot;
 import com.hello.suripu.core.db.DeviceDataIngestDAO;
 import com.hello.suripu.core.db.MergedUserInfoDynamoDB;
-import com.hello.suripu.core.flipper.FeatureFlipper;
 import com.hello.suripu.core.models.DeviceData;
-import com.hello.suripu.core.models.UserInfo;
+import com.hello.suripu.core.util.SenseProcessorUtils;
 import com.hello.suripu.workers.framework.HelloBaseRecordProcessor;
-import com.librato.rollout.RolloutClient;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.annotation.Timed;
 import com.yammer.metrics.core.Meter;
@@ -28,9 +23,6 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/sense/SenseSaveProcessor.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/sense/SenseSaveProcessor.java
@@ -1,6 +1,5 @@
 package com.hello.suripu.workers.sense;
 
-import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.InvalidStateException;
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
@@ -21,7 +20,7 @@ import com.hello.suripu.core.db.SensorsViewsDynamoDB;
 import com.hello.suripu.core.flipper.FeatureFlipper;
 import com.hello.suripu.core.models.DeviceAccountPair;
 import com.hello.suripu.core.models.DeviceData;
-import com.hello.suripu.core.models.UserInfo;
+import com.hello.suripu.core.util.SenseProcessorUtils;
 import com.hello.suripu.workers.framework.HelloBaseRecordProcessor;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.annotation.Timed;

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/sense/lastSeen/SenseLastSeenProcessor.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/sense/lastSeen/SenseLastSeenProcessor.java
@@ -19,7 +19,7 @@ import com.hello.suripu.core.db.WifiInfoDAO;
 import com.hello.suripu.core.models.DeviceData;
 import com.hello.suripu.core.models.WifiInfo;
 import com.hello.suripu.workers.framework.HelloBaseRecordProcessor;
-import com.hello.suripu.workers.sense.SenseProcessorUtils;
+import com.hello.suripu.core.util.SenseProcessorUtils;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.annotation.Timed;
 import com.yammer.metrics.core.Meter;


### PR DESCRIPTION
I'm not stoked about this change, our options are either:
1. Keep this class in workers and force firehose to depend on suripu-workers
2. Keep this class in workers and duplicate all the logic in firehose
3. Create a new magic package that contains this logic and have both workers and firehose include that
4. This PR

cc @pims 
