### PR TITLE
Remove 25dB trim

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/util/Bucketing.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/util/Bucketing.java
@@ -104,7 +104,7 @@ public class Bucketing {
                 } else {
                     audioPeakDB = deviceData.audioPeakDisturbancesDB;
                 }
-                sensorValue = DataUtils.calibrateAudio(DataUtils.dbIntToFloatAudioDecibels(deviceData.audioPeakBackgroundDB), DataUtils.dbIntToFloatAudioDecibels(audioPeakDB));
+                sensorValue = DataUtils.calibrateAudio(DataUtils.dbIntToFloatAudioDecibels(deviceData.audioPeakBackgroundDB), DataUtils.dbIntToFloatAudioDecibels(audioPeakDB), deviceData.firmwareVersion);
             } else if(sensorName.equals("wave_count")) {
                 sensorValue = deviceData.waveCount;
             } else if(sensorName.equals("hold_count")) {
@@ -169,7 +169,7 @@ public class Bucketing {
             } else {
                 audioPeakDB = deviceData.audioPeakDisturbancesDB;
             }
-            final float soundValue = DataUtils.calibrateAudio(DataUtils.dbIntToFloatAudioDecibels(deviceData.audioPeakBackgroundDB), DataUtils.dbIntToFloatAudioDecibels(audioPeakDB));
+            final float soundValue = DataUtils.calibrateAudio(DataUtils.dbIntToFloatAudioDecibels(deviceData.audioPeakBackgroundDB), DataUtils.dbIntToFloatAudioDecibels(audioPeakDB), deviceData.firmwareVersion);
             final float humidityValue = DataUtils.calibrateHumidity(deviceData.ambientTemperature, deviceData.ambientHumidity);
             final float temperatureValue = DataUtils.calibrateTemperature(deviceData.ambientTemperature);
             final float particulatesValue = DataUtils.convertRawDustCountsToDensity(deviceData.ambientAirQualityRaw, calibrationOptional);

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/CurrentRoomState.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/CurrentRoomState.java
@@ -138,7 +138,7 @@ public class CurrentRoomState {
         final float humidity = DataUtils.calibrateHumidity(rawTemperature, rawHumidity);
         final float temperature = DataUtils.calibrateTemperature(rawTemperature);
         final float particulates = DataUtils.convertRawDustCountsToDensity(rawDustMax, calibrationOptional);
-        final float sound = DataUtils.calibrateAudio(DataUtils.convertAudioRawToDB(rawBackgroundNoise), DataUtils.convertAudioRawToDB(rawPeakNoise));
+        final float sound = DataUtils.calibrateAudio(DataUtils.convertAudioRawToDB(rawBackgroundNoise), DataUtils.convertAudioRawToDB(rawPeakNoise), firmwareVersion);
         return fromTempHumidDustLightSound(temperature, humidity, particulates, rawLight, sound, new DateTime(timestamp, DateTimeZone.UTC), referenceTime, thresholdInMinutes, DEFAULT_TEMP_UNIT);
 
     }
@@ -177,7 +177,7 @@ public class CurrentRoomState {
         final float temp = DataUtils.calibrateTemperature(data.ambientTemperature);
         final float humidity = DataUtils.calibrateHumidity(data.ambientTemperature, data.ambientHumidity);
         final float light = data.ambientLightFloat; // dvt units values are already converted to lux
-        final float sound = DataUtils.calibrateAudio(DataUtils.dbIntToFloatAudioDecibels(data.audioPeakBackgroundDB), DataUtils.dbIntToFloatAudioDecibels(data.audioPeakDisturbancesDB));
+        final float sound = DataUtils.calibrateAudio(DataUtils.dbIntToFloatAudioDecibels(data.audioPeakBackgroundDB), DataUtils.dbIntToFloatAudioDecibels(data.audioPeakDisturbancesDB), data.firmwareVersion);
         // max value is in raw counts, conversion needed
         final float particulates = DataUtils.convertRawDustCountsToDensity(data.ambientAirQualityRaw, calibrationOptional);
         return fromTempHumidDustLightSound(temp, humidity, particulates, light, sound, data.dateTimeUTC, referenceTime, thresholdInMinutes, tempUnit);


### PR DESCRIPTION
This removes the trimming of values below the 25dB noise floor. Chris says this is no longer needed. Our actual noise floor is 40dB, which is subtracted out of the peak value. 25dB is added back in to give a false noise floor. 

This needs review. 

@pims Review, please. 
