### PR TITLE
Add "group by" to PartnerMotionTimeSeries

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/motion/PartnerMotionAtSecond.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/motion/PartnerMotionAtSecond.java
@@ -1,0 +1,26 @@
+package com.hello.suripu.core.models.motion;
+
+import com.google.common.base.Optional;
+import com.hello.suripu.core.models.TrackerMotion;
+import org.joda.time.DateTime;
+
+/**
+ * Created by jakepiccolo on 12/16/15.
+ */
+public class PartnerMotionAtSecond {
+    public final Boolean didMove;
+    public final Boolean didPartnerMove;
+    public final DateTime dateTime;
+    public final Optional<TrackerMotion> partnerMotion;
+
+    protected PartnerMotionAtSecond(final Boolean didMove,
+                                    final Boolean didPartnerMove,
+                                    final DateTime dateTime,
+                                    final Optional<TrackerMotion> partnerMotion)
+    {
+        this.didMove = didMove;
+        this.didPartnerMove = didPartnerMove;
+        this.dateTime = dateTime;
+        this.partnerMotion = partnerMotion;
+    }
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/motion/PartnerMotionTimeSeries.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/motion/PartnerMotionTimeSeries.java
@@ -1,9 +1,12 @@
 package com.hello.suripu.core.models.motion;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 import com.hello.suripu.core.models.TrackerMotion;
 import org.joda.time.DateTime;
 
 import java.util.List;
+import java.util.ListIterator;
 
 /**
  * Created by jakepiccolo on 12/7/15.
@@ -43,6 +46,60 @@ public class PartnerMotionTimeSeries {
 
     public TrackerMotionTimeSeries getRightTimeSeries() {
         return rightTimeSeries;
+    }
+
+    public List<TrackerMotionWithPartnerMotion> groupByLeft() {
+        return groupTimeSeries(leftTimeSeries, rightTimeSeries);
+    }
+
+    public List<TrackerMotionWithPartnerMotion> groupByRight() {
+        return groupTimeSeries(rightTimeSeries, leftTimeSeries);
+    }
+
+
+    private List<TrackerMotionWithPartnerMotion> groupTimeSeries(final TrackerMotionTimeSeries groupByTimeSeries,
+                                                                 final TrackerMotionTimeSeries otherTimeSeries)
+    {
+        final List<TrackerMotionWithPartnerMotion> results = Lists.newArrayList();
+
+        final List<TrackerMotion> groupByTrackerMotions = groupByTimeSeries.getTrackerMotions();
+        final List<MotionAtSecond> otherMotionAtSeconds = otherTimeSeries.asList();
+
+        final ListIterator<MotionAtSecond> otherIterator = otherMotionAtSeconds.listIterator();
+
+        for (final TrackerMotion currTrackerMotion: groupByTrackerMotions) {
+
+            final List<MotionAtSecond> currMotionAtSeconds = TrackerMotionTimeSeries.trackerMotionToMotionAtSeconds(currTrackerMotion);
+            final List<PartnerMotionAtSecond> partnerMotionAtSeconds = Lists.newArrayListWithExpectedSize(currMotionAtSeconds.size());
+
+            for (final MotionAtSecond groupByAtSecond: currMotionAtSeconds) {
+
+                while (otherIterator.hasNext()) {
+                    final MotionAtSecond otherAtSecond = otherIterator.next();
+                    if (otherAtSecond.dateTime.isAfter(groupByAtSecond.dateTime)) {
+                        // If we got to this point, it means there's no matching partnerMotion at this second :(
+                        partnerMotionAtSeconds.add(new PartnerMotionAtSecond(
+                                groupByAtSecond.didMove, false, groupByAtSecond.dateTime, Optional.<TrackerMotion>absent()));
+
+                        // Move the cursor back a step and move on to the next groupByAtSecond
+                        otherIterator.previous();
+                        break;
+                    } else if (otherAtSecond.dateTime.equals(groupByAtSecond.dateTime)) {
+                        // We found our match!
+                        partnerMotionAtSeconds.add(new PartnerMotionAtSecond(
+                                groupByAtSecond.didMove,
+                                otherAtSecond.didMove,
+                                groupByAtSecond.dateTime,
+                                Optional.of(otherAtSecond.trackerMotion)));
+                        break;
+                    }
+                }
+            }
+
+            results.add(new TrackerMotionWithPartnerMotion(currTrackerMotion, partnerMotionAtSeconds));
+        }
+
+        return results;
     }
 
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/motion/TrackerMotionWithPartnerMotion.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/motion/TrackerMotionWithPartnerMotion.java
@@ -1,0 +1,22 @@
+package com.hello.suripu.core.models.motion;
+
+import com.google.common.base.Optional;
+import com.hello.suripu.core.models.TrackerMotion;
+
+import java.util.List;
+
+/**
+ * Created by jakepiccolo on 12/16/15.
+ */
+public class TrackerMotionWithPartnerMotion {
+    public final TrackerMotion trackerMotion;
+    public final List<PartnerMotionAtSecond> partnerMotionAtSeconds;
+
+    protected TrackerMotionWithPartnerMotion(final TrackerMotion trackerMotion,
+                                             final List<PartnerMotionAtSecond> partnerMotionAtSeconds)
+    {
+        this.trackerMotion = trackerMotion;
+        this.partnerMotionAtSeconds = partnerMotionAtSeconds;
+    }
+
+}

--- a/suripu-core/src/test/java/com/hello/suripu/core/models/motion/PartnerMotionTimeSeriesTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/models/motion/PartnerMotionTimeSeriesTest.java
@@ -1,5 +1,6 @@
 package com.hello.suripu.core.models.motion;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.hello.suripu.core.models.TrackerMotion;
 import org.joda.time.DateTime;
@@ -52,6 +53,99 @@ public class PartnerMotionTimeSeriesTest {
         assertThat(timeSeries.getLeftTimeSeries().getEnd(), is(timeSeries.getRightTimeSeries().getEnd()));
         assertThat(timeSeries.getLeftTimeSeries().getAlignedMotionMasks().size(),
                 is(timeSeries.getRightTimeSeries().getAlignedMotionMasks().size()));
+    }
+
+
+    @Test
+    public void testGroupByLeft() {
+        final DateTime startTime = new DateTime(2015, 01, 01, 00, 00, DateTimeZone.UTC); // Midnight on Jan 1
+        final int myMotionOffset = 2;
+        final int partnerMotionOffset = 5;
+
+        final List<TrackerMotion> myMotions = ImmutableList.of(
+                makeMotion(1L, 7L, startTime.plusSeconds(myMotionOffset).plusMinutes(1)),
+                makeMotion(1L, 1L << 40, startTime.plusSeconds(myMotionOffset).plusMinutes(2)),
+                makeMotion(1L, 8L, startTime.plusSeconds(myMotionOffset).plusMinutes(3))
+        );
+
+        final List<TrackerMotion> partnerMotions = ImmutableList.of(
+                makeMotion(2L, 31L << 36, startTime.plusSeconds(partnerMotionOffset).plusMinutes(2)),
+                makeMotion(2L, 15L, startTime.plusSeconds(partnerMotionOffset).plusMinutes(3))
+        );
+
+        final PartnerMotionTimeSeries timeSeries = PartnerMotionTimeSeries.create(myMotions, partnerMotions);
+
+        final List<TrackerMotionWithPartnerMotion> grouped = timeSeries.groupByLeft();
+        assertThat(grouped.size(), is(myMotions.size()));
+        assertThat(grouped.get(0).trackerMotion, is(myMotions.get(0)));
+        assertThat(grouped.get(1).trackerMotion, is(myMotions.get(1)));
+        assertThat(grouped.get(2).trackerMotion, is(myMotions.get(2)));
+
+        // Inspect first trackerMotion. Should have no partner motions
+        for (final PartnerMotionAtSecond x: grouped.get(0).partnerMotionAtSeconds) {
+            assertThat(x.partnerMotion, is(Optional.<TrackerMotion>absent()));
+            assertThat(x.didPartnerMove, is(false));
+            // First 3 seconds should be true
+            if (x.dateTime.isBefore(startTime.plusSeconds(myMotionOffset + 3))) {
+                assertThat(x.didMove, is(true));
+            }
+        }
+
+        // Second one is a bit more complex. Should have some motion overlap.
+        for (final PartnerMotionAtSecond x : grouped.get(1).partnerMotionAtSeconds) {
+            assertThat(x.dateTime.isAfter(startTime.plusSeconds(myMotionOffset - 1).plusMinutes(1)), is(true));
+            assertThat(x.dateTime.isBefore(startTime.plusSeconds(myMotionOffset).plusMinutes(2)), is(true));
+
+            // Should be the only "on" bit for this TrackerMotion
+            if (x.dateTime.equals(startTime.plusMinutes(1).plusSeconds(myMotionOffset + 40))) {
+                assertThat(x.didMove, is(true));
+            } else {
+                assertThat(x.didMove, is(false));
+            }
+
+            // there should be 5 "on" bits for the partner motion
+            if (x.dateTime.isAfter(startTime.plusSeconds(myMotionOffset + 38).plusMinutes(1)) &&
+                    x.dateTime.isBefore(startTime.plusSeconds(myMotionOffset + 44).plusMinutes(1)))
+            {
+                assertThat(x.didPartnerMove, is(true));
+            } else {
+                assertThat(x.didPartnerMove, is(false));
+            }
+
+            if (x.dateTime.isBefore(startTime.plusMinutes(1).plusSeconds(partnerMotionOffset))) {
+                assertThat(x.partnerMotion, is(Optional.<TrackerMotion>absent()));
+            } else {
+                assertThat(x.partnerMotion.get(), is(partnerMotions.get(0)));
+            }
+        }
+
+        // Third one is a real doozy
+        for (final PartnerMotionAtSecond x : grouped.get(2).partnerMotionAtSeconds) {
+            assertThat(x.dateTime.isAfter(startTime.plusSeconds(myMotionOffset - 1).plusMinutes(2)), is(true));
+            assertThat(x.dateTime.isBefore(startTime.plusSeconds(myMotionOffset).plusMinutes(3)), is(true));
+
+            // Should be the only "on" bit for this TrackerMotion
+            if (x.dateTime.equals(startTime.plusMinutes(2).plusSeconds(myMotionOffset + 3))) {
+                assertThat(x.didMove, is(true));
+            } else {
+                assertThat(x.didMove, is(false));
+            }
+
+            // there should be 4 "on" bits for the partner motion
+            if (x.dateTime.isAfter(startTime.plusSeconds(partnerMotionOffset - 1).plusMinutes(2)) &&
+                    x.dateTime.isBefore(startTime.plusSeconds(partnerMotionOffset + 4).plusMinutes(2)))
+            {
+                assertThat(x.didPartnerMove, is(true));
+            } else {
+                assertThat(x.didPartnerMove, is(false));
+            }
+
+            if (x.dateTime.isBefore(startTime.plusMinutes(2).plusSeconds(partnerMotionOffset))) {
+                assertThat(x.partnerMotion.get(), is(partnerMotions.get(0)));
+            } else {
+                assertThat(x.partnerMotion.get(), is(partnerMotions.get(1)));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Simple API for working with partner time series data, allowing "grouping by" one pill's trackerMotions and associating partner motions to each of those trackerMotions. The best way to understand this is by looking at `PartnerMotionAtSecond` and `TrackerMotionWithPartnerMotion` first to understand the motivation, before getting into the nitty-gritty implementation details and funky unit tests.

cc @pims 
