### PR TITLE
Remove DeviceDataDAO (postgres version) from SuripuApp

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/InsightsResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/resources/v1/InsightsResource.java
@@ -4,10 +4,8 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.hello.suripu.core.db.AccountDAO;
-import com.hello.suripu.core.db.AggregateSleepScoreDAODynamoDB;
 import com.hello.suripu.core.db.InsightsDAODynamoDB;
 import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
-import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.TrendsInsightsDAO;
 import com.hello.suripu.core.models.Account;
 import com.hello.suripu.core.models.AggregateSleepStats;
@@ -42,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by kingshy on 10/24/14.
@@ -57,25 +56,19 @@ public class InsightsResource extends BaseResource {
 
     private final AccountDAO accountDAO;
     private final TrendsInsightsDAO trendsInsightsDAO;
-    private final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB;
-    private final TrackerMotionDAO trackerMotionDAO;
     private final InsightsDAODynamoDB insightsDAODynamoDB;
     private final SleepStatsDAODynamoDB sleepStatsDAODynamoDB;
-    private final InsightProcessor insightProcessor;
 
     @Inject
     RolloutClient feature;
 
-    public InsightsResource(final AccountDAO accountDAO, final TrendsInsightsDAO trendsInsightsDAO, final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB,
-                            final TrackerMotionDAO trackerMotionDAO, InsightsDAODynamoDB insightsDAODynamoDB,
-                            final SleepStatsDAODynamoDB sleepStatsDAODynamoDB, final InsightProcessor insightProcessor) {
+    public InsightsResource(final AccountDAO accountDAO, final TrendsInsightsDAO trendsInsightsDAO,
+                            InsightsDAODynamoDB insightsDAODynamoDB,
+                            final SleepStatsDAODynamoDB sleepStatsDAODynamoDB) {
         this.accountDAO = accountDAO;
         this.trendsInsightsDAO = trendsInsightsDAO;
-        this.scoreDAODynamoDB = scoreDAODynamoDB;
-        this.trackerMotionDAO = trackerMotionDAO;
         this.insightsDAODynamoDB = insightsDAODynamoDB;
         this.sleepStatsDAODynamoDB = sleepStatsDAODynamoDB;
-        this.insightProcessor = insightProcessor;
     }
 
     /**
@@ -225,7 +218,7 @@ public class InsightsResource extends BaseResource {
     private List<InsightCard> insightCardsWithInfoPreview(final List<InsightCard> insightCards) {
         final List<InsightCard> cardsWithPreview = new ArrayList<>();
         for (InsightCard card : insightCards) {
-            cardsWithPreview.add(card.withInfoPreview(insightProcessor.getInsightPreviewForCategory(card.category)));
+            cardsWithPreview.add(card.withInfoPreview(InsightProcessor.getInsightPreviewForCategory(card.category, trendsInsightsDAO)));
         }
         return cardsWithPreview;
     }

--- a/suripu-app/src/main/java/com/hello/suripu/app/v2/InsightsResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/v2/InsightsResource.java
@@ -1,12 +1,9 @@
 package com.hello.suripu.app.v2;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.hello.suripu.core.db.AccountDAO;
 import com.hello.suripu.core.db.InsightsDAODynamoDB;
 import com.hello.suripu.core.db.TrendsInsightsDAO;
-import com.hello.suripu.core.models.Account;
 import com.hello.suripu.core.models.Insights.InfoInsightCards;
 import com.hello.suripu.core.models.Insights.InsightCard;
 import com.hello.suripu.core.oauth.AccessToken;
@@ -14,7 +11,6 @@ import com.hello.suripu.core.oauth.OAuthScope;
 import com.hello.suripu.core.oauth.Scope;
 import com.hello.suripu.core.processors.InsightProcessor;
 import com.hello.suripu.core.processors.insights.IntroductionInsights;
-import com.hello.suripu.core.util.DateTimeUtil;
 import com.yammer.metrics.annotation.Timed;
 
 import org.joda.time.DateTime;
@@ -39,19 +35,13 @@ public class InsightsResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(InsightsResource.class);
     private static final int MAX_INSIGHTS_NUM = 20;
 
-    private final AccountDAO accountDAO;
     private final InsightsDAODynamoDB insightsDAODynamoDB;
     private final TrendsInsightsDAO trendsInsightsDAO;
-    private final InsightProcessor insightProcessor;
 
-    public InsightsResource(final AccountDAO accountDAO,
-                            final InsightsDAODynamoDB insightsDAODynamoDB,
-                            final TrendsInsightsDAO trendsInsightsDAO,
-                            final InsightProcessor insightProcessor) {
-        this.accountDAO = accountDAO;
+    public InsightsResource(final InsightsDAODynamoDB insightsDAODynamoDB,
+                            final TrendsInsightsDAO trendsInsightsDAO) {
         this.insightsDAODynamoDB = insightsDAODynamoDB;
         this.trendsInsightsDAO = trendsInsightsDAO;
-        this.insightProcessor = insightProcessor;
     }
 
     @Timed
@@ -98,10 +88,8 @@ public class InsightsResource {
      * @return List of InsightCard objects that contain info preview titles
      */
     private List<InsightCard> insightCardsWithInfoPreviewAndMissingImages(final List<InsightCard> insightCards) {
-        final Map<InsightCard.Category, String> categoryNames = insightProcessor.categoryNames();
+        final Map<InsightCard.Category, String> categoryNames = InsightProcessor.categoryNames(trendsInsightsDAO);
         return InsightsDAODynamoDB.backfillImagesBasedOnCategory(insightCards, categoryNames);
     }
-
-
 
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
@@ -389,7 +389,9 @@ public class InsightProcessor {
         return Optional.absent();
     }
 
-    public Optional<String> getInsightPreviewForCategory(final InsightCard.Category category) {
+    public static Optional<String> getInsightPreviewForCategory(final InsightCard.Category category,
+                                                                final TrendsInsightsDAO trendsInsightsDAO)
+    {
         final Map<String, String> insightInfoPreview = Maps.newHashMap();
         final ImmutableList<InfoInsightCards> infoInsightCards = trendsInsightsDAO.getAllGenericInsightCards();
 
@@ -403,7 +405,11 @@ public class InsightProcessor {
         return Optional.fromNullable(insightInfoPreview.get(category.toCategoryString()));
     }
 
-    public ImmutableMap<InsightCard.Category, String> categoryNames() {
+    public Optional<String> getInsightPreviewForCategory(final InsightCard.Category category) {
+        return getInsightPreviewForCategory(category, trendsInsightsDAO);
+    }
+
+    public static ImmutableMap<InsightCard.Category, String> categoryNames(final TrendsInsightsDAO trendsInsightsDAO) {
         final Map<InsightCard.Category, String> categoryNames = Maps.newHashMap();
 
         final ImmutableList<InfoInsightCards> infoInsightCards = trendsInsightsDAO.getAllGenericInsightCards();
@@ -412,6 +418,10 @@ public class InsightProcessor {
             categoryNames.put(card.category, card.categoryName);
         }
         return ImmutableMap.copyOf(categoryNames);
+    }
+
+    public ImmutableMap<InsightCard.Category, String> categoryNames() {
+        return categoryNames(trendsInsightsDAO);
     }
 
     private Set<InsightCard.Category> getRecentInsightsCategories(final Long accountId) {


### PR DESCRIPTION
@pims My best magic trick yet!
- Remove need for `InsightProcessor` in `InsightsResource`(s) via a bit of refactoring
- Keep `InsightProcessor` backwards-compatible, in case suripu-research or admin use those methods
- Therefore, we no longer need `DeviceDataDAO`!

Next steps:
1. The only thing sensorsdb is used for in the app now is `TrackerMotionDAO`, so we need to refactor it away the same way I've done here.
2. Once that's done, we can fully remove any usage of sensorsdb from the app.
