### PR TITLE
Admin Server Error Discussion [DO NOT MERGE]

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDataDAODynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDataDAODynamoDB.java
@@ -677,6 +677,8 @@ public class DeviceDataDAODynamoDB extends TimeSeriesDAODynamoDB<DeviceData> imp
                                                             final int startHour,
                                                             final int endHour)
     {
+        //TODO: deviceId.externalDeviceId may be absent - catch here or refactor DeviceId itself and pass in a different object?
+
         final String externalDeviceId = deviceId.externalDeviceId.get();
 
         final Expression filterExp = Expressions.and(

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/DeviceId.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/DeviceId.java
@@ -16,6 +16,7 @@ public class DeviceId {
         this.externalDeviceId = externalDeviceId;
     }
 
+    //What's the best way for not confusing the below two different "types" of DeviceId?
     public static DeviceId create(@NotNull final Long internalDeviceId) {
         return new DeviceId(Optional.of(internalDeviceId), Optional.<String>absent());
     }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
@@ -131,6 +131,7 @@ public class InsightProcessor {
 
         if (featureFlipper.userFeatureActive(FeatureFlipper.DYNAMODB_DEVICE_DATA_INSIGHTS, accountId, Collections.EMPTY_LIST)) {
             LOGGER.info("Generating insights with DynamoDB for account {}", accountId);
+            //This try never succeeds because deviceId was created with internalDeviceId above, and the below requires the externalId type of deviceId
             try {
                 this.generateGeneralInsights(accountId, deviceId, deviceDataDAODynamoDB, featureFlipper);
                 return;


### PR DESCRIPTION
Found the source of the server error I was experiencing when trying to trigger insights via the admin endpoint:
- It appears the source is some ambiguity in the creation of object `DeviceId` with either the external id or the internal id. The 500 server error itself occurred because a particular `deviceId` was created with the internal id, and `deviceId.externalId.get()` was called for it.
- `The InsightProcessor` worker is not affected by this (yay!) because the above call is within a try/catch, and InsightGeneration with an alternative fallback method which does not require the externalId.get() is called.

@pims @jakepic1 What are your thoughts about the best way to do the necessary changes?

I'll send a PR fixing the issue in `suripu-admin` but I'd like to understand this issue more, especially for `InsightProcessor`. 
