### PR TITLE
Increase Insights variety

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
@@ -255,8 +255,7 @@ public class InsightProcessor {
         return Optional.absent();
     }
 
-    @VisibleForTesting
-    public Optional<InsightCard.Category> selectHighPriorityInsightToGenerate(final Long accountId, final Set<InsightCard.Category> recentCategories, final DateTime currentTime, final RolloutClient featureFlipper) {
+    private Optional<InsightCard.Category> selectHighPriorityInsightToGenerate(final Long accountId, final Set<InsightCard.Category> recentCategories, final DateTime currentTime, final RolloutClient featureFlipper) {
 
         //TODO: Read category to generate off of an external file to allow for most flexibility
         return Optional.absent();

--- a/suripu-core/src/test/java/com/hello/suripu/core/processors/InsightProcessorTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/processors/InsightProcessorTest.java
@@ -238,9 +238,6 @@ public class InsightProcessorTest {
         assertThat(wakeCardCategory.isPresent(), is(Boolean.FALSE));
 
         //look for high priority Insight - get nothing
-        Mockito.verify(spyInsightProcessor).selectHighPriorityInsightToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_SATURDAY, mockFeatureFlipper);
-        Optional<InsightCard.Category> expectedHighPriority = insightProcessor.selectHighPriorityInsightToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_SATURDAY, mockFeatureFlipper);
-        assertThat(expectedHighPriority.isPresent(), is(Boolean.FALSE));
 
         //look for random old Insight - get nothing b/c wrong date
         Mockito.verify(spyInsightProcessor).selectRandomOldInsightsToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_SATURDAY, mockFeatureFlipper);
@@ -272,7 +269,6 @@ public class InsightProcessorTest {
         assertThat(wakeCardCategory.isPresent(), is(Boolean.FALSE));
 
         //look for high priority Insight - get nothing b/c feature wrong date
-        Mockito.verify(spyInsightProcessor).selectHighPriorityInsightToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_SATURDAY, mockFeatureFlipper);
 
         //look for random old Insight - get nothing b/c wrong date
         Mockito.verify(spyInsightProcessor).selectRandomOldInsightsToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_SATURDAY, mockFeatureFlipper);
@@ -303,7 +299,6 @@ public class InsightProcessorTest {
         Mockito.verify(spyInsightProcessor, Mockito.never()).generateInsightsByCategory(FAKE_ACCOUNT_ID, FAKE_DEVICE_ID, deviceDataDAO, InsightCard.Category.WAKE_VARIANCE);
 
         //look for high priority Insight - get nothing
-        Mockito.verify(spyInsightProcessor).selectHighPriorityInsightToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_DATE_1, mockFeatureFlipper);
 
         //look for random old Insight, do not try to generate humidity b/c featureFlip Off
         Mockito.verify(spyInsightProcessor).selectRandomOldInsightsToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_DATE_1, mockFeatureFlipper);
@@ -332,7 +327,6 @@ public class InsightProcessorTest {
         Mockito.verify(spyInsightProcessor, Mockito.never()).generateInsightsByCategory(FAKE_ACCOUNT_ID, FAKE_DEVICE_ID, deviceDataDAO, InsightCard.Category.WAKE_VARIANCE);
 
         //look for high priority Insight - get nothing
-        Mockito.verify(spyInsightProcessor).selectHighPriorityInsightToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_DATE_1, mockFeatureFlipper);
 
         //look for random old Insight, try to generate humidity
         Mockito.verify(spyInsightProcessor).selectRandomOldInsightsToGenerate(FAKE_ACCOUNT_ID, recentCategories, FAKE_DATE_1, mockFeatureFlipper);


### PR DESCRIPTION
Had conversation with @kevintwohy that repeat insights become much more obvious now that images are displayed.

Previously:
Try to generate (4 possible) "high priority" categories on specific days, and if those "high priority" insights fail, generate "old insights." It happened that for some users the high priority categories succeeded every time, so that each month the user only saw those insights.

Now:
Space out all possible Insight categories (currently 7 categories) spaced every 3 days. Full loop once a month. 

Later:
Next year will implement reading scheduling from external file to allow more flexibility with the scheduling. This will be especially helpful when we want news article/current event based Insights. 
