### PR TITLE
Insights timezone query refactoring [DO NOT MERGE]

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/InsightProcessor.java
@@ -13,6 +13,7 @@ import com.hello.suripu.core.db.DeviceDataInsightQueryDAO;
 import com.hello.suripu.core.db.DeviceReadDAO;
 import com.hello.suripu.core.db.InsightsDAODynamoDB;
 import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
+import com.hello.suripu.core.db.TimeZoneHistoryDAODynamoDB;
 import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.TrendsInsightsDAO;
 import com.hello.suripu.core.flipper.FeatureFlipper;
@@ -51,6 +52,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -69,6 +71,7 @@ public class InsightProcessor {
     private final DeviceDataDAO deviceDataDAO;
     private final DeviceDataDAODynamoDB deviceDataDAODynamoDB;
     private final DeviceReadDAO deviceReadDAO;
+    private final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB;
     private final TrendsInsightsDAO trendsInsightsDAO;
     private final TrackerMotionDAO trackerMotionDAO;
     private final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB;
@@ -83,6 +86,7 @@ public class InsightProcessor {
     public InsightProcessor(@NotNull final DeviceDataDAO deviceDataDAO,
                             @NotNull final DeviceDataDAODynamoDB deviceDataDAODynamoDB,
                             @NotNull final DeviceReadDAO deviceReadDAO,
+                            @NotNull final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB,
                             @NotNull final TrendsInsightsDAO trendsInsightsDAO,
                             @NotNull final TrackerMotionDAO trackerMotionDAO,
                             @NotNull final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB,
@@ -97,6 +101,7 @@ public class InsightProcessor {
         this.deviceDataDAO = deviceDataDAO;
         this.deviceDataDAODynamoDB = deviceDataDAODynamoDB;
         this.deviceReadDAO = deviceReadDAO;
+        this.timeZoneHistoryDAODynamoDB = timeZoneHistoryDAODynamoDB;
         this.trendsInsightsDAO = trendsInsightsDAO;
         this.trackerMotionDAO = trackerMotionDAO;
         this.scoreDAODynamoDB = scoreDAODynamoDB;
@@ -345,7 +350,7 @@ public class InsightProcessor {
         Optional<InsightCard> insightCardOptional = Optional.absent();
         switch (category) {
             case AIR_QUALITY:
-                insightCardOptional = Particulates.getInsights(accountId, deviceId, sleepStatsDAODynamoDB, deviceDataInsightQueryDAO, calibrationDAO);
+                insightCardOptional = Particulates.getInsights(accountId, deviceId, timeZoneHistoryDAODynamoDB, deviceDataInsightQueryDAO, calibrationDAO);
                 break;
             case BED_LIGHT_DURATION:
                 insightCardOptional = BedLightDuration.getInsights(accountId, deviceId, deviceDataInsightQueryDAO, sleepStatsDAODynamoDB);
@@ -457,6 +462,7 @@ public class InsightProcessor {
         private @Nullable DeviceDataDAO deviceDataDAO;
         private @Nullable DeviceDataDAODynamoDB deviceDataDAODynamoDB;
         private @Nullable DeviceReadDAO deviceReadDAO;
+        private @Nullable TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB;
         private @Nullable TrendsInsightsDAO trendsInsightsDAO;
         private @Nullable TrackerMotionDAO trackerMotionDAO;
         private @Nullable AggregateSleepScoreDAODynamoDB scoreDAODynamoDB;
@@ -472,6 +478,11 @@ public class InsightProcessor {
             this.deviceReadDAO = deviceReadDAO;
             this.deviceDataDAO = deviceDataDAO;
             this.deviceDataDAODynamoDB = deviceDataDAODynamoDB;
+            return this;
+        }
+
+        public Builder withTimeZoneHistoryDAO(final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB) {
+            this.timeZoneHistoryDAODynamoDB = timeZoneHistoryDAODynamoDB;
             return this;
         }
 
@@ -520,6 +531,7 @@ public class InsightProcessor {
         public InsightProcessor build() {
             checkNotNull(deviceDataDAO, "deviceDataDAO can not be null");
             checkNotNull(deviceReadDAO, "deviceReadDAO can not be null");
+            checkNotNull(timeZoneHistoryDAODynamoDB, "timeZoneHistoryDAO can not be null");
             checkNotNull(trendsInsightsDAO, "trendsInsightsDAO can not be null");
             checkNotNull(trackerMotionDAO, "trackerMotionDAO can not be null");
             checkNotNull(scoreDAODynamoDB, "scoreDAODynamoDB can not be null");
@@ -531,7 +543,10 @@ public class InsightProcessor {
             checkNotNull(wakeStdDevData, "wakeStdDevData cannot be null");
             checkNotNull(calibrationDAO, "calibrationDAO cannot be null");
 
-            return new InsightProcessor(deviceDataDAO, deviceDataDAODynamoDB, deviceReadDAO,
+            return new InsightProcessor(deviceDataDAO,
+                    deviceDataDAODynamoDB,
+                    deviceReadDAO,
+                    timeZoneHistoryDAODynamoDB,
                     trendsInsightsDAO,
                     trackerMotionDAO,
                     scoreDAODynamoDB, insightsDAODynamoDB,

--- a/suripu-core/src/test/java/com/hello/suripu/core/processors/InsightProcessorTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/processors/InsightProcessorTest.java
@@ -10,6 +10,7 @@ import com.hello.suripu.core.db.DeviceDataDAO;
 import com.hello.suripu.core.db.DeviceDataDAODynamoDB;
 import com.hello.suripu.core.db.InsightsDAODynamoDB;
 import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
+import com.hello.suripu.core.db.TimeZoneHistoryDAODynamoDB;
 import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.TrendsInsightsDAO;
 import com.hello.suripu.core.db.responses.DeviceDataResponse;
@@ -88,6 +89,7 @@ public class InsightProcessorTest {
         final DeviceDataDAODynamoDB deviceDataDAODynamoDB = Mockito.mock(DeviceDataDAODynamoDB.class);
         final DeviceDAO deviceDAO = Mockito.mock(DeviceDAO.class);
         Mockito.when(deviceDAO.getMostRecentSenseByAccountId(FAKE_ACCOUNT_ID)).thenReturn(Optional.of(FAKE_DEVICE_ID));
+        final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB = Mockito.mock(TimeZoneHistoryDAODynamoDB.class);
         final TrendsInsightsDAO trendsInsightsDAO = Mockito.mock(TrendsInsightsDAO.class);
         final TrackerMotionDAO trackerMotionDAO = Mockito.mock(TrackerMotionDAO.class);
         final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB = Mockito.mock(AggregateSleepScoreDAODynamoDB.class);
@@ -145,7 +147,10 @@ public class InsightProcessorTest {
         Mockito.when(insightsDAODynamoDB.getInsightsByCategory(FAKE_ACCOUNT_ID, InsightCard.Category.HUMIDITY, 1)).thenReturn(ImmutableList.copyOf(mockInsightCardList));
 
         //Initialize InsightProcessor
-        final InsightProcessor insightProcessor = new InsightProcessor(deviceDataDAO, deviceDataDAODynamoDB, deviceDAO,
+        final InsightProcessor insightProcessor = new InsightProcessor(deviceDataDAO,
+                deviceDataDAODynamoDB,
+                deviceDAO,
+                timeZoneHistoryDAODynamoDB,
                 trendsInsightsDAO,
                 trackerMotionDAO,
                 scoreDAODynamoDB,

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/insights/InsightsGeneratorFactory.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/insights/InsightsGeneratorFactory.java
@@ -14,6 +14,7 @@ import com.hello.suripu.core.db.InsightsDAODynamoDB;
 import com.hello.suripu.core.db.QuestionResponseDAO;
 import com.hello.suripu.core.db.QuestionResponseReadDAO;
 import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
+import com.hello.suripu.core.db.TimeZoneHistoryDAODynamoDB;
 import com.hello.suripu.core.db.TrackerMotionDAO;
 import com.hello.suripu.core.db.TrendsInsightsDAO;
 import com.hello.suripu.core.preferences.AccountPreferencesDAO;
@@ -31,6 +32,7 @@ public class InsightsGeneratorFactory implements IRecordProcessorFactory {
     private final DeviceDataDAO deviceDataDAO;
     private final DeviceDataDAODynamoDB deviceDataDAODynamoDB;
     private final DeviceReadDAO deviceDAO;
+    private final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB;
     private final TrackerMotionDAO trackerMotionDAO;
     private final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB;
     private final InsightsDAODynamoDB insightsDAODynamoDB;
@@ -46,6 +48,7 @@ public class InsightsGeneratorFactory implements IRecordProcessorFactory {
                                     final DeviceDataDAO deviceDataDAO,
                                     final DeviceDataDAODynamoDB deviceDataDAODynamoDB,
                                     final DeviceDAO deviceDAO,
+                                    final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB,
                                     final TrackerMotionDAO trackerMotionDAO,
                                     final AggregateSleepScoreDAODynamoDB scoreDAODynamoDB,
                                     final InsightsDAODynamoDB insightsDAODynamoDB,
@@ -60,6 +63,7 @@ public class InsightsGeneratorFactory implements IRecordProcessorFactory {
         this.deviceDataDAO = deviceDataDAO;
         this.deviceDataDAODynamoDB = deviceDataDAODynamoDB;
         this.deviceDAO = deviceDAO;
+        this.timeZoneHistoryDAODynamoDB = timeZoneHistoryDAODynamoDB;
         this.trackerMotionDAO = trackerMotionDAO;
         this.scoreDAODynamoDB = scoreDAODynamoDB;
         this.insightsDAODynamoDB = insightsDAODynamoDB;
@@ -81,6 +85,7 @@ public class InsightsGeneratorFactory implements IRecordProcessorFactory {
 
         final InsightProcessor.Builder insightBuilder = new InsightProcessor.Builder()
                 .withSenseDAOs(deviceDataDAO, deviceDataDAODynamoDB, deviceDAO)
+                .withTimeZoneHistoryDAO(timeZoneHistoryDAODynamoDB)
                 .withTrackerMotionDAO(trackerMotionDAO)
                 .withInsightsDAO(trendsInsightsDAO)
                 .withDynamoDBDAOs(scoreDAODynamoDB, insightsDAODynamoDB, sleepStatsDAODynamoDB)

--- a/suripu-workers/src/main/java/com/hello/suripu/workers/insights/InsightsGeneratorWorkerCommand.java
+++ b/suripu-workers/src/main/java/com/hello/suripu/workers/insights/InsightsGeneratorWorkerCommand.java
@@ -12,6 +12,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.hello.suripu.core.ObjectGraphRoot;
 import com.hello.suripu.core.db.DeviceDataDAODynamoDB;
+import com.hello.suripu.core.db.TimeZoneHistoryDAODynamoDB;
 import com.hello.suripu.coredw.clients.AmazonDynamoDBClientFactory;
 import com.hello.suripu.core.configuration.DynamoDBTableName;
 import com.hello.suripu.core.configuration.QueueName;
@@ -181,6 +182,9 @@ public class InsightsGeneratorWorkerCommand extends WorkerEnvironmentCommand<Ins
         final AmazonDynamoDB deviceDataDAODynamoDBClient = amazonDynamoDBClientFactory.getInstrumented(DynamoDBTableName.DEVICE_DATA, DeviceDataDAODynamoDB.class);
         final DeviceDataDAODynamoDB deviceDataDAODynamoDB = new DeviceDataDAODynamoDB(deviceDataDAODynamoDBClient, tableNames.get(DynamoDBTableName.DEVICE_DATA));
 
+        final AmazonDynamoDB timeZoneHistoryDAODynamoDBClient = amazonDynamoDBClientFactory.getInstrumented(DynamoDBTableName.TIMEZONE_HISTORY, TimeZoneHistoryDAODynamoDB.class);
+        final TimeZoneHistoryDAODynamoDB timeZoneHistoryDAODynamoDB = new TimeZoneHistoryDAODynamoDB(timeZoneHistoryDAODynamoDBClient, tableNames.get(DynamoDBTableName.TIMEZONE_HISTORY));
+
         final WorkerRolloutModule workerRolloutModule = new WorkerRolloutModule(featureStore, 30);
         ObjectGraphRoot.getInstance().init(workerRolloutModule);
 
@@ -193,6 +197,7 @@ public class InsightsGeneratorWorkerCommand extends WorkerEnvironmentCommand<Ins
                 deviceDataDAO,
                 deviceDataDAODynamoDB,
                 deviceDAO,
+                timeZoneHistoryDAODynamoDB,
                 trackerMotionDAO,
                 aggregateSleepScoreDAODynamoDB,
                 insightsDAODynamoDB,


### PR DESCRIPTION
**Previously**:
- query using `SleepStatsDAO` for DateTime.now(timezone.UTC).minusDays(3) to get timezone. (minus 3 days was chosen because of timezone/query time exceptions. 
- clearly, this leads to a lot of insights not being generated, because of the requirement that there be a timeline on a specific day. Since most insights come from data purely from `device_data`, this is an unnecessary requirement. 

**Now**:
- Grab (one) any timezone from the last 7 days using `TimeZoneHistoryDAODynamoDB`

**TODO**:
- tests
- local testing
- convert for other all insights

cc: @kingshyg 
