### PR TITLE
Fix IllegalArgumentException for Yellow/Aqua pills

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/device/v2/Pill.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/device/v2/Pill.java
@@ -12,9 +12,12 @@ public class Pill {
     public static final Color DEFAULT_COLOR = Color.BLUE;
     private static final Integer MIN_IDEAL_BATTERY_LEVEL = 15;
 
+    // These should match the colors in `PillColorUtil`
     public enum Color {
         BLUE("BLUE"),
-        RED("RED");
+        RED("RED"),
+        AQUA("AQUA"),
+        YELLOW("YELLOW");
 
         private final String value;
         Color(final String value) {

--- a/suripu-core/src/test/java/com/hello/suripu/core/models/device/v2/PillTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/models/device/v2/PillTest.java
@@ -1,0 +1,22 @@
+package com.hello.suripu.core.models.device.v2;
+
+import com.hello.suripu.core.models.Device;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Created by jakepiccolo on 1/12/16.
+ */
+public class PillTest {
+
+    @Test
+    public void testFromDeviceColor() throws Exception {
+        final Pill.Color redColor = Pill.Color.fromDeviceColor(Device.Color.RED);
+        assertThat(redColor, is(Pill.Color.RED));
+
+        final Pill.Color aquaColor = Pill.Color.fromDeviceColor(Device.Color.AQUA);
+        assertThat(aquaColor, is(Pill.Color.AQUA));
+    }
+}


### PR DESCRIPTION
Causing device info endpoint to throw 500's when a user has an Aqua pill.
