### PR TITLE
bugfix for bypassing timeline safeguard

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -746,7 +746,7 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         //if there is no feedback, we have a "natural" timeline
         //check if this natural timeline makes sense.  If not, set sleep score to zero.
         if (feedbackList.isEmpty() && sleepStats.sleepDurationInMinutes < TimelineSafeguards.MINIMUM_SLEEP_DURATION_MINUTES) {
-            LOGGER.warn("Score for account id {} was set to zero because sleep duration is too short ({} min)", accountId, sleepStats.sleepDurationInMinutes);
+            LOGGER.warn("action=zeroing-score account_id={} reason=sleep-duration-too-short sleep_duration={}", accountId, sleepStats.sleepDurationInMinutes);
             sleepScore = 0;
         }
 


### PR DESCRIPTION
bug: if the final voting alg (the backup) generated a too-short duration timeline, it would not get caught in populateTimeline and produce a very strange timeline for users.

We used to check duration in populateTimeline, but disabled this via feature flipper now.  It was disabled because the user could modify his/her timeline into an invalid state.  The timeline would then not be returned.

So the check is: If there's no feedback (i.e. it's a completely algorithm-generated timeline), and the duration is too short, we assume the alg fucked up, and return an invalid timeline.

No tests, because we don't have an easy way of testing (ALTHOUGH WE SHOULD) TimelineProcessor.  Yolo.  Test locally on a few users, fixes bad case, doesn't harm normal timelines.
