### PR TITLE
bugfix: fix log timestamp

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -229,7 +229,7 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         final Long testGroup = getTestGroup(accountId,targetDate,sensorData.timezoneOffsetMillis);
 
         //create log with test grup
-        final TimelineLog log = new TimelineLog(accountId,targetDate.withZone(DateTimeZone.UTC).getMillis(),testGroup);
+        final TimelineLog log = new TimelineLog(accountId,targetDate.withZone(DateTimeZone.UTC).getMillis(),DateTime.now(DateTimeZone.UTC).getMillis(),testGroup);
 
 
 


### PR DESCRIPTION
using wrong constructor when constructing log message
