### PR TITLE
Fixed bug caused by new dec firmware version stored in build info

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/firmware/FirmwareUpdateStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/firmware/FirmwareUpdateStore.java
@@ -475,7 +475,7 @@ public class FirmwareUpdateStore {
         }
     }
 
-    public static Optional<Integer> getFirmwareVersionFromBuildInfo(final String buildInfoText) {
+    static Optional<Integer> getFirmwareVersionFromBuildInfo(final String buildInfoText) {
         final Iterable<String> strings = Splitter.on("\n").split(buildInfoText);
         final Map<String, String> buildInfo = Maps.newHashMap();
 
@@ -484,6 +484,10 @@ public class FirmwareUpdateStore {
                 final String[] parts = line.split(":");
                 buildInfo.put(parts[0].trim(), parts[1].trim());
             }
+        }
+
+        if (!buildInfo.containsKey("version")) {
+            return Optional.absent();
         }
 
         if (buildInfo.get("version").isEmpty()) {

--- a/suripu-core/src/test/java/com/hello/suripu/core/firmware/FirmwareUpdateStoreTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/firmware/FirmwareUpdateStoreTest.java
@@ -81,6 +81,13 @@ public class FirmwareUpdateStoreTest {
             "travis_build_number: 9999\n" +
             "travis_job_id: 30867510\n" +
             "travis_job_number: 3300.1";
+        final String badBuildInfo = "last_tag: 1.0.5.3.3\n" +
+            "travis_branch: alphas\n" +
+            "travis_tag: \n" +
+            "travis_build_id: 19896757\n" +
+            "travis_build_number: 9999\n" +
+            "travis_job_id: 30867510\n" +
+            "travis_job_number: 3300.1";
 
         Optional<Integer> fwVersion = FirmwareUpdateStore.getFirmwareVersionFromBuildInfo(oldFirmwareBuildInfo);
         assertThat(fwVersion.isPresent(), is(true));
@@ -93,5 +100,8 @@ public class FirmwareUpdateStoreTest {
         fwVersion = FirmwareUpdateStore.getFirmwareVersionFromBuildInfo(newFirmwareBadBuildInfo);
         assertThat(fwVersion.isPresent(), is(true));
         assertThat(fwVersion.get(), is(13056));
+
+        fwVersion = FirmwareUpdateStore.getFirmwareVersionFromBuildInfo(badBuildInfo);
+        assertThat(fwVersion.isPresent(), is(false));
     }
 }


### PR DESCRIPTION
With the new Travis build number based fw version numbers, the build_info.txt file no longer contains a hex value. This was breaking the retrieval of the firmware files from s3 and ultimately causing alpha units to continuously retry OTA. 

@pims Review, please. A PR for Service will follow to update the pom for this new version of core. 
