### PR TITLE
outlier filter

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -59,6 +59,7 @@ public class FeatureFlipper {
     public final static String ONLINE_HMM_ALGORITHM = "online_hmm_algorithm";
     public final static String ONLINE_HMM_LEARNING = "online_hmm_learning";
     public final static String OTA_RELEASE = "release";
+    public final static String OUTLIER_FILTER = "outlier_filter";
 
     public final static String PARTNER_FILTER = "partner_filter";
     public final static String PCH_SPECIAL_OTA = "pch_special_ota";

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/FeatureFlippedProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/FeatureFlippedProcessor.java
@@ -122,4 +122,8 @@ public class FeatureFlippedProcessor {
         return featureFlipper.userFeatureActive(FeatureFlipper.DYNAMODB_PILL_DATA_TIMELINE, accountId, Collections.EMPTY_LIST);
     }
 
+    protected Boolean hasOutlierFilterEnabled(final long accountId) {
+        return featureFlipper.userFeatureActive(FeatureFlipper.OUTLIER_FILTER,accountId,Collections.EMPTY_LIST);
+    }
+
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -49,6 +49,7 @@ import com.hello.suripu.core.translations.English;
 import com.hello.suripu.core.util.AlgorithmType;
 import com.hello.suripu.core.util.DateTimeUtil;
 import com.hello.suripu.core.util.FeedbackUtils;
+import com.hello.suripu.core.util.OutlierFilter;
 import com.hello.suripu.core.util.PartnerDataUtils;
 import com.hello.suripu.core.util.SensorDataTimezoneMap;
 import com.hello.suripu.core.util.SleepScoreUtils;
@@ -100,12 +101,9 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
     public final static int MIN_DURATION_OF_TRACKER_MOTION_IN_HOURS = 5;
     public final static int MIN_DURATION_OF_FILTERED_MOTION_IN_HOURS = 3;
     public final static int MIN_MOTION_AMPLITUDE = 1000;
+    final static long OUTLIER_GUARD_DURATION = DateTimeConstants.MILLIS_PER_HOUR * 4; //min spacing between motion groups
+    final static long DOMINANT_GROUP_DURATION = DateTimeConstants.MILLIS_PER_HOUR * 5; //num hours in a motion group to be considered the dominant one
 
-    public final static String ALGORITHM_NAME_REGULAR = "wupang";
-    public final static String ALGORITHM_NAME_VOTING = "voting";
-    public final static String ALGORITHM_NAME_BAYESNET = "bayesnet";
-    public final static String ALGORITHM_NAME_HMM = "hmm";
-    public final static String VERSION_BACKUP = "wupang_backup_for_hmm"; //let us know the HMM had some issues
 
 
     static public TimelineProcessor createTimelineProcessor(final PillDataReadDAO pillDataDAODynamoDB,
@@ -259,6 +257,7 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         }
 
 
+        /*  GET THE TIMELINE! */
         Optional<TimelineAlgorithmResult> resultOptional = Optional.absent();
 
         for (final AlgorithmType alg : algorithmChain) {
@@ -348,20 +347,31 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
 
         // get partner tracker motion, if available
         final List<TrackerMotion> originalPartnerMotions = getPartnerTrackerMotion(accountId, starteTimeLocalUTC, endTimeLocalUTC);
-        final List<TrackerMotion> trackerMotions = new ArrayList<>();
 
-        if (!originalPartnerMotions.isEmpty()) {
+
+        List<TrackerMotion> filteredOriginalMotions = originalTrackerMotions;
+        List<TrackerMotion> filteredOriginalPartnerMotions = originalPartnerMotions;
+
+        if (this.hasOutlierFilterEnabled(accountId)) {
+            filteredOriginalMotions = OutlierFilter.removeOutliers(originalTrackerMotions,OUTLIER_GUARD_DURATION,DOMINANT_GROUP_DURATION);
+            filteredOriginalPartnerMotions = OutlierFilter.removeOutliers(originalPartnerMotions,OUTLIER_GUARD_DURATION,DOMINANT_GROUP_DURATION);
+        }
+
+
+        final List<TrackerMotion> trackerMotions = Lists.newArrayList();
+
+        if (!filteredOriginalPartnerMotions.isEmpty()) {
 
             final int tzOffsetMillis = originalTrackerMotions.get(0).offsetMillis;
 
             if (this.hasPartnerFilterEnabled(accountId)) {
                 LOGGER.info("using original partner filter");
                 try {
-                    PartnerDataUtils.PartnerMotions motions = partnerDataUtils.getMyMotion(originalTrackerMotions, originalPartnerMotions);
+                    PartnerDataUtils.PartnerMotions motions = partnerDataUtils.getMyMotion(filteredOriginalMotions, filteredOriginalPartnerMotions);
                     trackerMotions.addAll(motions.myMotions);
                 } catch (Exception e) {
                     LOGGER.error(e.getMessage());
-                    trackerMotions.addAll(originalTrackerMotions);
+                    trackerMotions.addAll(filteredOriginalMotions);
                 }
             }
             else if (this.hasHmmPartnerFilterEnabled(accountId)) {
@@ -371,20 +381,20 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
                             partnerDataUtils.partnerFilterWithDurationsDiffHmm(
                                     starteTimeLocalUTC.minusMillis(tzOffsetMillis),
                                     endTimeLocalUTC.minusMillis(tzOffsetMillis),
-                                    ImmutableList.copyOf(originalTrackerMotions),
-                                    ImmutableList.copyOf(originalPartnerMotions)));
+                                    ImmutableList.copyOf(filteredOriginalMotions),
+                                    ImmutableList.copyOf(filteredOriginalPartnerMotions)));
 
                 } catch (Exception e) {
                     LOGGER.error(e.getMessage());
-                    trackerMotions.addAll(originalTrackerMotions);
+                    trackerMotions.addAll(filteredOriginalMotions);
                 }
             }
             else {
-                trackerMotions.addAll(originalTrackerMotions);
+                trackerMotions.addAll(filteredOriginalMotions);
             }
         }
         else {
-            trackerMotions.addAll(originalTrackerMotions);
+            trackerMotions.addAll(filteredOriginalMotions);
         }
 
         if (trackerMotions.isEmpty()) {
@@ -435,9 +445,9 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
         }
 
         return Optional.of(new OneDaysSensorData(allSensorSampleList,
-                ImmutableList.copyOf(trackerMotions),ImmutableList.copyOf(originalPartnerMotions),
+                ImmutableList.copyOf(trackerMotions),ImmutableList.copyOf(filteredOriginalPartnerMotions),
                 ImmutableList.copyOf(feedbackList),
-                ImmutableList.copyOf(originalTrackerMotions),ImmutableList.copyOf(originalPartnerMotions),
+                ImmutableList.copyOf(filteredOriginalMotions),ImmutableList.copyOf(filteredOriginalPartnerMotions),
                 date,starteTimeLocalUTC,endTimeLocalUTC,currentTimeUTC,
                 tzOffsetMillis));
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/util/OutlierFilter.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/OutlierFilter.java
@@ -1,0 +1,129 @@
+package com.hello.suripu.core.util;
+
+import com.google.common.collect.Lists;
+import com.hello.suripu.core.models.TrackerMotion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Created by benjo on 1/26/16.
+ */
+public class OutlierFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OutlierFilter.class);
+    final public static long MIN_MOTION = 1L;
+    final public static int MIN_MOTION_MAGNITUDE = 300;
+
+    protected static class MotionGroupsWithDuration implements  Comparable<MotionGroupsWithDuration> {
+        public final long duration;
+        public final List<TrackerMotion> motions;
+
+        // ASSUMES MOTIONS ARE ALREADY TIME-SORTED
+        public MotionGroupsWithDuration(final List<TrackerMotion> motions) {
+            this.motions = motions;
+
+            if (this.motions.isEmpty()) {
+                duration = 0;
+            }
+            else {
+                duration = motions.get(motions.size() - 1).timestamp - motions.get(0).timestamp;
+            }
+        }
+
+
+        @Override
+        public int compareTo(MotionGroupsWithDuration o) {
+            if (o.duration < this.duration) {
+                return -1;
+            }
+
+            if (o.duration > this.duration) {
+                return 1;
+            }
+
+            return 0;
+        }
+    }
+
+    public static List<TrackerMotion> removeOutliers(final List<TrackerMotion> trackerMotions, final long outlierGuardDurationMillis, final long dominantGroupDuration) {
+
+        if (trackerMotions.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+
+        // FILTER OUT ALL "SMALL" MOTIONS"
+        final List<TrackerMotion> realPoints = Lists.newArrayList();
+        for (final Iterator<TrackerMotion> it = trackerMotions.iterator(); it.hasNext(); ) {
+            final TrackerMotion m = it.next();
+
+            if (m.onDurationInSeconds > MIN_MOTION || m.value > MIN_MOTION_MAGNITUDE) {
+                realPoints.add(m);
+            }
+
+        }
+
+        //I managed to filter out all the points, good job.
+        if (realPoints.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        final List<List<TrackerMotion>> groups = Lists.newArrayList();
+
+        List<TrackerMotion> currentGroup = Lists.newArrayList();
+
+        TrackerMotion prev = null;
+        for (final Iterator<TrackerMotion> it = realPoints.iterator(); it.hasNext(); ) {
+            final TrackerMotion m = it.next();
+
+
+
+            if (prev != null) {
+                final long tdiff = m.timestamp - prev.timestamp;
+
+                if (tdiff  > outlierGuardDurationMillis) {
+                    groups.add(currentGroup);
+                    currentGroup = Lists.newArrayList();
+                }
+
+            }
+
+            prev = m;
+            currentGroup.add(m);
+
+        }
+
+        groups.add(currentGroup);
+
+        //sort groups
+        List<MotionGroupsWithDuration> groupsWithDurations = Lists.newArrayList();
+
+        for (final List<TrackerMotion> motions : groups) {
+            groupsWithDurations.add(new MotionGroupsWithDuration(motions));
+        }
+
+        Collections.sort(groupsWithDurations);
+
+        //THE RULE IS -- IF YOU HAVE A GROUP WITH DURATION > N HOURS as the longest duration, discard the rest.
+        if (groupsWithDurations.size() > 1) {
+            if (groupsWithDurations.get(0).duration > dominantGroupDuration) {
+
+                int pointcount = 0;
+
+                for (int i = 1; i < groupsWithDurations.size(); i++) {
+                    pointcount += groupsWithDurations.get(i).motions.size();
+                }
+
+                LOGGER.info("action=discard_my_tracker_motion num_points={}",pointcount);
+
+                return groupsWithDurations.get(0).motions;
+            }
+        }
+
+        return trackerMotions;
+    }
+}

--- a/suripu-core/src/test/java/com/hello/suripu/core/util/OutlierFilterTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/OutlierFilterTest.java
@@ -1,0 +1,58 @@
+package com.hello.suripu.core.util;
+
+import com.google.common.collect.Lists;
+import com.hello.suripu.core.models.TrackerMotion;
+import junit.framework.TestCase;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Created by benjo on 1/26/16.
+ */
+public class OutlierFilterTest {
+
+
+    @Test
+    public void testOutlierFilter() {
+        final List<TrackerMotion> nominalTrackerMotion = Lists.newArrayList();
+        final long t0 = 1453831241000L;
+
+        for (int i = 0; i < 8; i++) {
+            nominalTrackerMotion.add(new TrackerMotion(0L,0L,0L,t0 + i*DateTimeConstants.MILLIS_PER_HOUR,4999,0,0L,0L,3L));
+        }
+
+        final List<TrackerMotion> separatedTrackerMotions = Lists.newArrayList();
+
+        for (int i = 0; i < 4; i++) {
+            separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 + i*DateTimeConstants.MILLIS_PER_HOUR,5000,0,0L,0L,3L));
+        }
+
+        for (int i = 0; i < 9; i++) {
+            separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 + i*DateTimeConstants.MILLIS_PER_HOUR + DateTimeConstants.MILLIS_PER_DAY,5001,0,0L,0L,3L));
+        }
+
+        for (int i = 0; i < 2; i++) {
+            separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 + i*DateTimeConstants.MILLIS_PER_HOUR +  2*DateTimeConstants.MILLIS_PER_DAY,5002,0,0L,0L,3L));
+        }
+
+
+        final List<TrackerMotion> motionsNominal = OutlierFilter.removeOutliers(nominalTrackerMotion,DateTimeConstants.MILLIS_PER_HOUR*5,DateTimeConstants.MILLIS_PER_HOUR*3);
+        TestCase.assertTrue(motionsNominal.size() == 8);
+
+        final List<TrackerMotion> motionsSeparated = OutlierFilter.removeOutliers(separatedTrackerMotions,DateTimeConstants.MILLIS_PER_HOUR*5,DateTimeConstants.MILLIS_PER_HOUR*3);
+        TestCase.assertTrue(motionsSeparated.size() == 9);
+        for (int i = 0; i < 9; i++) {
+            TestCase.assertTrue(motionsSeparated.get(i).value == 5001);
+        }
+
+
+        separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 -DateTimeConstants.MILLIS_PER_HOUR  + DateTimeConstants.MILLIS_PER_DAY,100,0,0L,0L,1L));
+        final List<TrackerMotion> motionsSeparated2 = OutlierFilter.removeOutliers(separatedTrackerMotions,DateTimeConstants.MILLIS_PER_HOUR*5,DateTimeConstants.MILLIS_PER_HOUR*3);
+        TestCase.assertTrue(motionsSeparated.size() == 9);
+
+    }
+
+}


### PR DESCRIPTION
Two groups of motion, one spanning 5 hours, the other 1 hour, and they are separated by 4 hours of no motion.  The goal is to discard the 1 hour group. 

Alternately, two groups, separated by 4 hours, but each one hour in duration.  Neither group meets the minimum duration of 5 hours, so return all motion.

This is to help with the maid problem.

Feature flipped.
