### PR TITLE
outlier filter now takes care of maid problem only

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/TimelineProcessor.java
@@ -101,9 +101,8 @@ public class TimelineProcessor extends FeatureFlippedProcessor {
     public final static int MIN_DURATION_OF_TRACKER_MOTION_IN_HOURS = 5;
     public final static int MIN_DURATION_OF_FILTERED_MOTION_IN_HOURS = 3;
     public final static int MIN_MOTION_AMPLITUDE = 1000;
-    final static long OUTLIER_GUARD_DURATION = DateTimeConstants.MILLIS_PER_HOUR * 4; //min spacing between motion groups
-    final static long DOMINANT_GROUP_DURATION = DateTimeConstants.MILLIS_PER_HOUR * 5; //num hours in a motion group to be considered the dominant one
-
+    final static long OUTLIER_GUARD_DURATION = (long)(DateTimeConstants.MILLIS_PER_HOUR * 2.0); //min spacing between motion groups
+    final static long DOMINANT_GROUP_DURATION = (long)(DateTimeConstants.MILLIS_PER_HOUR * 6.0); //num hours in a motion group to be considered the dominant one
 
 
     static public TimelineProcessor createTimelineProcessor(final PillDataReadDAO pillDataDAODynamoDB,

--- a/suripu-core/src/test/java/com/hello/suripu/core/util/OutlierFilterTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/OutlierFilterTest.java
@@ -38,20 +38,31 @@ public class OutlierFilterTest {
             separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 + i*DateTimeConstants.MILLIS_PER_HOUR +  2*DateTimeConstants.MILLIS_PER_DAY,5002,0,0L,0L,3L));
         }
 
+        for (int i = 0; i < 2; i++) {
+            separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 + i*DateTimeConstants.MILLIS_PER_HOUR +  3*DateTimeConstants.MILLIS_PER_DAY,5002,0,0L,0L,3L));
+        }
 
-        final List<TrackerMotion> motionsNominal = OutlierFilter.removeOutliers(nominalTrackerMotion,DateTimeConstants.MILLIS_PER_HOUR*5,DateTimeConstants.MILLIS_PER_HOUR*3);
+        final long dominantGroupDuration = DateTimeConstants.MILLIS_PER_HOUR*5;
+        final long gapDuration = DateTimeConstants.MILLIS_PER_HOUR*3;
+
+        final List<TrackerMotion> motionsNominal = OutlierFilter.removeOutliers(nominalTrackerMotion,dominantGroupDuration,gapDuration);
         TestCase.assertTrue(motionsNominal.size() == 8);
 
-        final List<TrackerMotion> motionsSeparated = OutlierFilter.removeOutliers(separatedTrackerMotions,DateTimeConstants.MILLIS_PER_HOUR*5,DateTimeConstants.MILLIS_PER_HOUR*3);
-        TestCase.assertTrue(motionsSeparated.size() == 9);
-        for (int i = 0; i < 9; i++) {
+        final List<TrackerMotion> motionsSeparated = OutlierFilter.removeOutliers(separatedTrackerMotions,dominantGroupDuration,gapDuration);
+        TestCase.assertTrue(motionsSeparated.size() == 13);
+        for (int i = 0; i < 4; i++) {
+            TestCase.assertTrue(motionsSeparated.get(i).value == 5000);
+        }
+
+        for (int i = 4; i < 13; i++) {
             TestCase.assertTrue(motionsSeparated.get(i).value == 5001);
         }
 
 
+        //ignore the weak motion
         separatedTrackerMotions.add(new TrackerMotion(0L,0L,0L,t0 -DateTimeConstants.MILLIS_PER_HOUR  + DateTimeConstants.MILLIS_PER_DAY,100,0,0L,0L,1L));
-        final List<TrackerMotion> motionsSeparated2 = OutlierFilter.removeOutliers(separatedTrackerMotions,DateTimeConstants.MILLIS_PER_HOUR*5,DateTimeConstants.MILLIS_PER_HOUR*3);
-        TestCase.assertTrue(motionsSeparated.size() == 9);
+        final List<TrackerMotion> motionsSeparated2 = OutlierFilter.removeOutliers(separatedTrackerMotions,dominantGroupDuration,gapDuration);
+        TestCase.assertTrue(motionsSeparated.size() == 13);
 
     }
 


### PR DESCRIPTION
A lot of people go into deep sleep and may have no motion for over 4 hours after going to bed.  The original implementation would then reject the user's in-bed data points because they were too far away from the main group. 

This version just looks AFTER the dominant group (i.e. addresses the maid problem) for points to reject.  The no-motion gap required to segment is now two hours.  

This means if the main group of motion duration is > 6 hours, and there's a period of no motion for 2 hours, it will just cut off the rest of the motion data at the start of the period of no motion.

Generally speaking, people have a lot of movement before they wake up, so there are generally no data gaps unless the user gets out of bed.
