### PR TITLE
feedback suggests new event time according to order difference

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/FeedbackUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/FeedbackUtils.java
@@ -317,7 +317,7 @@ public class FeedbackUtils {
     public ReprocessedEvents reprocessEventsBasedOnFeedback(final ImmutableList<TimelineFeedback> timelineFeedbackList, final ImmutableCollection<Event> algEvents, final ImmutableList<Event> extraEvents, final Integer offsetMillis) {
 
 
-        /* get events by time  */
+        /* get feedback events by time  */
         final Map<Event.Type,Event> eventsByType = getFeedbackAsEventsByType(timelineFeedbackList, offsetMillis);
 
 
@@ -657,12 +657,14 @@ public class FeedbackUtils {
 
         //if I violated the sequence of the event that comes after, then place the propsoed event one minute before that event
         if (failHigh) {
-            return  Optional.of(highEntry.getValue() - MINUTE);
+            final int indexDiff = myOrder - highEntry.getKey();
+            return  Optional.of(highEntry.getValue() + indexDiff * MINUTE);
         }
 
         //as above, but for the event that comes before
         if (failLow) {
-            return Optional.of(lowerEntry.getValue() + MINUTE);
+            final int indexDiff = myOrder - lowerEntry.getKey();
+            return Optional.of(lowerEntry.getValue() + indexDiff*MINUTE);
         }
 
         //should also never get here either, but whatever


### PR DESCRIPTION
feedback suggests new event time according to order difference
event orders:
IN_BED = 0
SLEEP = 1
WAKE_UP = 2
OUT_OF_BED = 3

So if you move **IN_BED to 9am** for some idiotic reason, you now get get
09:00 - IN_BED 
09:01 - SLEEP 
09:02 - WAKE_UP 
09:03 - OUT_OF_BED

where currently you'd get
09:00 - IN_BED 
09:01 - WAKE_UP 
09:02 - OUT_OF_BED

because differences of +/- 1 minute are suggested,
