### PR TITLE
trends bug fixes

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/SleepStatsDAO.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/SleepStatsDAO.java
@@ -20,5 +20,4 @@ public interface SleepStatsDAO {
     Optional<AggregateSleepStats> getSingleStat(Long accountId, String date);
 
     ImmutableList<AggregateSleepStats> getBatchStats(Long accountId, String startDate, String endDate);
-
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/db/SleepStatsDAODynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/SleepStatsDAODynamoDB.java
@@ -212,9 +212,7 @@ public class SleepStatsDAODynamoDB implements SleepStatsDAO {
 
     
     @Override
-    public ImmutableList<AggregateSleepStats> getBatchStats(final Long accountId,
-                                                            final String startDate,
-                                                            final String endDate) {
+    public ImmutableList<AggregateSleepStats> getBatchStats(final Long accountId, final String startDate, final String endDate) {
 
         final Condition selectByAccountId = new Condition()
                 .withComparisonOperator(ComparisonOperator.EQ)

--- a/suripu-core/src/main/java/com/hello/suripu/core/trends/v2/TrendsProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/trends/v2/TrendsProcessor.java
@@ -249,7 +249,7 @@ public class TrendsProcessor {
     private List<AggregateSleepStats> getRawData(final Long accountId, final DateTime localToday, final int days) {
         final DateTime queryStart = localToday.minusDays(days);
 
-        final List<AggregateSleepStats> rawData = sleepStatsDAODynamoDB.getBatchStats(2350L,
+        final List<AggregateSleepStats> rawData = sleepStatsDAODynamoDB.getBatchStats(accountId,
                 DateTimeUtil.dateToYmdString(queryStart),
                 DateTimeUtil.dateToYmdString(localToday));
 


### PR DESCRIPTION
- update min valid data size for bars and bubbles to 7 nights
- remove nights with less than 30 mins sleep duration
- round averages to 1 decimal
