### PR TITLE
More Trends Fixes

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/trends/v2/TrendsProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/trends/v2/TrendsProcessor.java
@@ -69,7 +69,7 @@ public class TrendsProcessor {
         final List<TimeScale> timeScales = computeAvailableTimeScales(accountAge);
 
         // get raw data
-        final List<AggregateSleepStats> data = getRawData(55024L, localToday, timescale.getDays());
+        final List<AggregateSleepStats> data = getRawData(accountId, localToday, timescale.getDays());
 
         if (data.isEmpty()) {
             LOGGER.debug("debug=no-trends-data, account={}", accountId);
@@ -178,8 +178,8 @@ public class TrendsProcessor {
 
         // computing averages
         final List<Float> validData = Lists.newArrayList();
-        float minValue = 10000.0f;
-        float maxValue = 0.0f;
+        float maxValue = Float.MIN_VALUE;
+        float minValue = Float.MAX_VALUE;
         DateTime currentDateTime = data.get(0).dateTime;
 
         for (final AggregateSleepStats stat: data) {
@@ -231,12 +231,12 @@ public class TrendsProcessor {
 
         final List<Float> sectionData = TrendsProcessorUtils.padSectionData(validData, localToday, data.get(0).dateTime, currentDateTime, timeScale, padDayOfWeek, optionalCreated);
 
-        if (data.size() < MIN_DATA_SIZE_SHOW_MINMAX) {
-            minValue = -1.0f;
-            maxValue = -1.0f;
-
+        final boolean hasMinMaxValues = (data.size() >= MIN_DATA_SIZE_SHOW_MINMAX);
+        if (!hasMinMaxValues) {
+            minValue = 0.0f;
         }
-        final List<GraphSection> sections = TrendsProcessorUtils.getScoreDurationSections(sectionData, minValue, maxValue, dataType, timeScale, localToday);
+
+        final List<GraphSection> sections = TrendsProcessorUtils.getScoreDurationSections(sectionData, minValue, maxValue, dataType, timeScale, localToday, hasMinMaxValues);
 
         final List<Annotation> annotations = Lists.newArrayList();
         if (hasAnnotation) {


### PR DESCRIPTION
1. account created just after midnight, data returned was off by 1
2. don't highlight min/max values with less than 3 night's of data
3. bug fix for case where a new duration month/3month section has only 1 day of data
4. account-age < 3 days, no graph => "Welcome to Trends" graphic will be shown
5. all other accounts require 3 valid night's data before any graphs are returned.
