### PR TITLE
Adding feature for allowing sleep sounds status to override OTAs

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -88,6 +88,7 @@ public class FeatureFlipper {
     public final static String SLEEP_SCORE_DURATION_V2 = "sleep_score_duration_v2";
     public final static String SLEEP_SCORE_TIMES_AWAKE_PENALTY = "sleep_score_times_awake_penalty";
     public final static String SLEEP_SOUNDS_ENABLED = "sleep_sounds_enabled";
+    public final static String SLEEP_SOUNDS_OVERRIDE_OTA = "sleep_sounds_override_ota";
     public final static String SLEEP_SEGMENT_OFFSET_REMAPPING = "sleep_segment_offset_remapping";
     public final static String SLEEP_STATS_MEDIUM_SLEEP = "sleep_stats_medium_sleep";
     public final static String SMART_ALARM = "smart_alarm";


### PR DESCRIPTION
Added this feature to allow a playing sleep sound to clear the OTA file download list. PR in suripu-service to follow...

@pims @jakepic1 
