### PR TITLE
Convert volume percent to linear decibel scaling factor

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/v2/SleepSoundsResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/v2/SleepSoundsResource.java
@@ -395,13 +395,14 @@ public class SleepSoundsResource extends BaseResource {
      *
      * @param maxDecibels Maximum desired decibels for Sense to play (at 100%)
      * @param volumePercent "Perceived" volume percentage (100% is loudest, 50% is half of that, etc).
+     *                      Must be in (0, 100].
      * @return Linear scaling factor for Sense to convert to decibels.
      */
     @VisibleForTesting
     protected static Integer convertVolumePercent(final Double maxDecibels,
                                                   final Integer volumePercent) {
-        if (volumePercent > 100 || volumePercent < 0) {
-            throw new IllegalArgumentException(String.format("volumePercent must be in the range [0, 100], not %s", volumePercent));
+        if (volumePercent > 100 || volumePercent <= 0) {
+            throw new IllegalArgumentException(String.format("volumePercent must be in the range (0, 100], not %s", volumePercent));
         }
         // Formula/constants obtained from http://www.sengpielaudio.com/calculator-loudness.htm
         final double decibelOffsetFromMaximum = 33.22 * Math.log10(volumePercent / 100.0);

--- a/suripu-app/src/test/java/com/hello/suripu/app/v2/SleepSoundsResourceTest.java
+++ b/suripu-app/src/test/java/com/hello/suripu/app/v2/SleepSoundsResourceTest.java
@@ -408,7 +408,6 @@ public class SleepSoundsResourceTest {
         assertThat(SleepSoundsResource.convertVolumePercent(100), is(100));
         assertThat(SleepSoundsResource.convertVolumePercent(50), is(83));
         assertThat(SleepSoundsResource.convertVolumePercent(25), is(67));
-        assertThat(SleepSoundsResource.convertVolumePercent(0), is(0));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -418,7 +417,7 @@ public class SleepSoundsResourceTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConvertVolumePercentTooSmall() {
-        SleepSoundsResource.convertVolumePercent(-1);
+        SleepSoundsResource.convertVolumePercent(0);
     }
     // endregion convertVolumePercent
 }


### PR DESCRIPTION
Increasing decibel levels don't sound linear to our ears, but the expectation app-side is that the volume increases will be linear. Thus, convert what the app sends us as a "perceived" percentage to a linear scaling factor that sense can use (factor \* max_decibels = decibels_to_play).

cc @pims @jnorgan @kingshyg @plasticchris 
