### PR TITLE
Stop querying when limit is hit

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/TimeSeriesDAODynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/TimeSeriesDAODynamoDB.java
@@ -306,6 +306,12 @@ public abstract class TimeSeriesDAODynamoDB<T> {
                 }
             }
 
+            if ((originalQueryRequest.getLimit() != null) &&
+                    (results.size() >= originalQueryRequest.getLimit()))
+            {
+                return Response.success(results);
+            }
+
             lastEvaluatedKey = queryResult.getLastEvaluatedKey();
             keepTrying = (lastEvaluatedKey != null);
 


### PR DESCRIPTION
cc @pims 

This should reduce latency of the current room conditions query substantially, and should also reduce logspam that looks like 

``````
Exceeded 5 attempts while querying. Stopping with last evaluated key: {aid={N: 25127,}, ts|dev={S: 2016-04-08 00:37|15619153AD1BF9F7,}}```
``````
