### PR TITLE
Add size_bytes to file_info table

### DIFF
--- a/sql/common/create.sql
+++ b/sql/common/create.sql
@@ -395,3 +395,5 @@ GRANT ALL PRIVILEGES ON sleep_sound_durations TO ingress_user;
 GRANT ALL PRIVILEGES ON sleep_sounds TO ingress_user;
 GRANT ALL PRIVILEGES ON file_info TO ingress_user;
 GRANT ALL PRIVILEGES ON sense_file_info TO ingress_user;
+
+ALTER TABLE file_info ADD COLUMN size_bytes INTEGER;

--- a/suripu-core/src/main/java/com/hello/suripu/core/db/mappers/FileInfoMapper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/mappers/FileInfoMapper.java
@@ -24,6 +24,7 @@ public class FileInfoMapper implements ResultSetMapper<FileInfo> {
                 .withName(resultSet.getString("name"))
                 .withFirmwareVersion(resultSet.getInt("firmware_version"))
                 .withIsPublic(resultSet.getBoolean("is_public"))
+                .withSizeBytes(resultSet.getInt("size_bytes"))
                 .build();
     }
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/FileInfo.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/FileInfo.java
@@ -36,6 +36,8 @@ public class FileInfo {
 
     final Boolean isPublic;
 
+    public final Integer sizeBytes;
+
     private FileInfo(Builder builder) {
         id = builder.id;
         path = builder.path;
@@ -46,6 +48,7 @@ public class FileInfo {
         name = builder.name;
         firmwareVersion = builder.firmwareVersion;
         isPublic = builder.isPublic;
+        sizeBytes = builder.sizeBytes;
 
         checkNotNull(id, "id must not be null");
         checkNotNull(path, "path must not be null");
@@ -76,6 +79,7 @@ public class FileInfo {
         private String name;
         private Integer firmwareVersion;
         private Boolean isPublic = false;
+        private Integer sizeBytes;
 
         private Builder() {
         }
@@ -122,6 +126,11 @@ public class FileInfo {
 
         public Builder withIsPublic(Boolean val) {
             isPublic = val;
+            return this;
+        }
+
+        public Builder withSizeBytes(final Integer val) {
+            sizeBytes = val;
             return this;
         }
 

--- a/suripu-core/src/test/java/com/hello/suripu/core/db/FileInfoDAOTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/db/FileInfoDAOTest.java
@@ -34,7 +34,8 @@ public class FileInfoDAOTest extends SqlDAOTest<FileInfoDAO> {
                 "    uri VARCHAR(255),\n" +
                 "    preview_uri VARCHAR(255),\n" +
                 "    name VARCHAR(255),\n" +
-                "    is_public BOOLEAN DEFAULT FALSE\n" +
+                "    is_public BOOLEAN DEFAULT FALSE,\n" +
+                "    size_bytes INTEGER\n" +
                 ");\n" +
                 "\n" +
                 "CREATE TABLE sense_file_info (\n" +
@@ -46,8 +47,8 @@ public class FileInfoDAOTest extends SqlDAOTest<FileInfoDAO> {
 
     private void insert(final Long id, final Integer sortKey, final Integer firmwareVersion, final Boolean isPublic)
     {
-        final String insertStatement = "Insert INTO file_info (id, sort_key, firmware_version, is_public, type, path, sha, uri, preview_uri, name)\n" +
-                "VALUES (:id, :sort_key, :firmware_version, :is_public, 'SLEEP_SOUND', '', '', '', '', '');";
+        final String insertStatement = "Insert INTO file_info (id, sort_key, firmware_version, is_public, type, path, sha, uri, preview_uri, name, size_bytes)\n" +
+                "VALUES (:id, :sort_key, :firmware_version, :is_public, 'SLEEP_SOUND', '', '', '', '', '', 0);";
         handle.createStatement(insertStatement)
                 .bind("id", id)
                 .bind("sort_key", sortKey)


### PR DESCRIPTION
Making it easier to modify the FileManifest response based on expected file size (i.e. don't download a file if Sense doesn't have enough space left).

cc @pims @jnorgan @kingshyg 
