### PR TITLE
Revert "Base sleep sound display limit on num sounds available"

### DIFF
--- a/suripu-app/src/test/java/com/hello/suripu/app/v2/SleepSoundsResourceTest.java
+++ b/suripu-app/src/test/java/com/hello/suripu/app/v2/SleepSoundsResourceTest.java
@@ -365,12 +365,11 @@ public class SleepSoundsResourceTest {
     @Test
     public void testGetSounds() throws Exception {
         final Long soundId = 1L;
-        final int numSounds = 11;
 
         Mockito.when(deviceDAO.getMostRecentSensePairByAccountId(accountId)).thenReturn(pair);
 
         final List<FileInfo> fileInfoList = Lists.newArrayList();
-        for (int i = 0; i < numSounds; i++) {
+        for (int i = 0; i < 5; i++) {
             fileInfoList.add(FileInfo.newBuilder()
                     .withId(soundId + i)
                     .withPreviewUri("preview")
@@ -387,15 +386,15 @@ public class SleepSoundsResourceTest {
                 .withId(soundId + fileInfoList.size())
                 .withPreviewUri("preview")
                 .withName("name")
-                .withPath("/path/to/file")
+                .withPath("/wrong/path/to/file")
                 .withUri("url")
                 .withFirmwareVersion(1)
                 .withIsPublic(true)
                 .withSha("11")
-                .withFileType(FileInfo.FileType.ALARM)
+                .withFileType(FileInfo.FileType.SLEEP_SOUND)
                 .build());
 
-        Mockito.when(fileInfoDAO.getAll(Mockito.anyInt(), Mockito.anyString())).thenReturn(fileInfoList);
+        Mockito.when(fileInfoDAO.getAllForType(FileInfo.FileType.SLEEP_SOUND)).thenReturn(fileInfoList);
 
         final FileSync.FileManifest fileManifest = FileSync.FileManifest.newBuilder()
                 .addFileInfo(FileSync.FileManifest.File.newBuilder()
@@ -409,8 +408,8 @@ public class SleepSoundsResourceTest {
         Mockito.when(fileManifestDAO.getManifest(Mockito.anyString())).thenReturn(Optional.of(fileManifest));
 
         final SleepSoundsProcessor.SoundResult soundResult = sleepSoundsResource.getSounds(token);
+        assertThat(soundResult.sounds.size(), is(5));
         assertThat(soundResult.state, is(SleepSoundsProcessor.SoundResult.State.OK));
-        assertThat(soundResult.sounds.size(), is(numSounds));
         for (int i = 0; i < soundResult.sounds.size(); i++) {
             assertThat(soundResult.sounds.get(i).id, is(soundId + i));
         }
@@ -436,19 +435,8 @@ public class SleepSoundsResourceTest {
                     .withFileType(FileInfo.FileType.SLEEP_SOUND)
                     .build());
         }
-        fileInfoList.add(FileInfo.newBuilder()
-                .withId(soundId + fileInfoList.size())
-                .withPreviewUri("preview")
-                .withName("name")
-                .withPath("/wrong/path/to/file")
-                .withUri("url")
-                .withFirmwareVersion(1)
-                .withIsPublic(true)
-                .withSha("11")
-                .withFileType(FileInfo.FileType.SLEEP_SOUND)
-                .build());
 
-        Mockito.when(fileInfoDAO.getAll(Mockito.anyInt(), Mockito.anyString())).thenReturn(fileInfoList);
+        Mockito.when(fileInfoDAO.getAllForType(FileInfo.FileType.SLEEP_SOUND)).thenReturn(fileInfoList);
 
         final FileSync.FileManifest fileManifest = FileSync.FileManifest.newBuilder()
                 .addFileInfo(FileSync.FileManifest.File.newBuilder()

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/SleepSoundsProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/SleepSoundsProcessor.java
@@ -23,7 +23,9 @@ import java.util.List;
  */
 public class SleepSoundsProcessor implements SoundMap {
     private static final Logger LOGGER = LoggerFactory.getLogger(SleepSoundsProcessor.class);
-    
+
+    private static final Integer MIN_SOUNDS = 5; // Anything less than this and we return an empty list.
+
     private final FileInfoDAO fileInfoDAO;
     private final FileManifestDAO fileManifestDAO;
 
@@ -84,19 +86,7 @@ public class SleepSoundsProcessor implements SoundMap {
             return new SoundResult(sounds, SoundResult.State.SENSE_UPDATE_REQUIRED);
         }
 
-        final int firmwareVersion = manifestOptional.get().hasFirmwareVersion()
-                ? manifestOptional.get().getFirmwareVersion()
-                : 0;
-
-        final List<FileInfo> fileInfoList = fileInfoDAO.getAll(firmwareVersion, senseId);
-
-        final List<FileInfo> sleepSoundFileInfoList = Lists.newArrayList();
-        for (final FileInfo fileInfo: fileInfoList) {
-            if (fileInfo.fileType == FileInfo.FileType.SLEEP_SOUND) {
-                sleepSoundFileInfoList.add(fileInfo);
-            }
-        }
-
+        final List<FileInfo> sleepSoundFileInfoList = fileInfoDAO.getAllForType(FileInfo.FileType.SLEEP_SOUND);
         LOGGER.debug("sense-id={} sleep-sound-file-info-list-size={} file-manifest-file-count={}",
                 senseId, sleepSoundFileInfoList.size(), manifestOptional.get().getFileInfoCount());
 
@@ -107,7 +97,7 @@ public class SleepSoundsProcessor implements SoundMap {
             }
         }
 
-        if (sounds.size() < sleepSoundFileInfoList.size()) {
+        if (sounds.size() < MIN_SOUNDS) {
             LOGGER.warn("endpoint=sounds error=not-enough-sounds sense-id={} num-sounds={}",
                     senseId, sounds.size());
             return new SoundResult(Lists.<Sound>newArrayList(), SoundResult.State.SOUNDS_NOT_DOWNLOADED);


### PR DESCRIPTION
Reverts hello/suripu#1601

There was a bug in this commit that would return duplicate sounds (presumably from the `sense_file_info` inserts). Will fix and re-commit.
