### PR TITLE
Feature flipper that Sense is updating when displaying Sleep Sounds

### DIFF
--- a/suripu-app/src/main/java/com/hello/suripu/app/v2/SleepSoundsResource.java
+++ b/suripu-app/src/main/java/com/hello/suripu/app/v2/SleepSoundsResource.java
@@ -41,6 +41,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -289,6 +290,11 @@ public class SleepSoundsResource extends BaseResource {
         if (!hasSleepSoundsEnabled(accountId)) {
             LOGGER.debug("endpoint=sleep-sounds sleep-sounds-enabled=false account-id={}", accountId);
             throw new WebApplicationException(Response.Status.NO_CONTENT);
+        }
+
+        if (hasSleepSoundsDisplayFirmwareUpdate(accountId)) {
+            LOGGER.debug("endpoint=sleep-sounds sleep-sounds-enabled=true sleep-sounds-display-fw-update=true account-id={}", accountId);
+            return new SleepSoundsProcessor.SoundResult(Collections.<Sound>emptyList(), SleepSoundsProcessor.SoundResult.State.SENSE_UPDATE_REQUIRED);
         }
 
         LOGGER.info("endpoint=sleep-sounds sleep-sounds-enabled=true account-id={}", accountId);

--- a/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/flipper/FeatureFlipper.java
@@ -90,7 +90,13 @@ public class FeatureFlipper {
     public final static String SLEEP_SCORE_DURATION_WEIGHTING_V2 = "sleep_score_duration_weighting_V2";
     public final static String SLEEP_SCORE_DURATION_V2 = "sleep_score_duration_v2";
     public final static String SLEEP_SCORE_TIMES_AWAKE_PENALTY = "sleep_score_times_awake_penalty";
+
+    // Return enum to the app that Sleep Sounds cannot be played because Sense requires a firmware update
+    public final static String SLEEP_SOUNDS_DISPLAY_FW_UPDATE = "sleep_sounds_display_fw_update";
+
+    // Show the Sleep Sounds UI in the app
     public final static String SLEEP_SOUNDS_ENABLED = "sleep_sounds_enabled";
+
     public final static String SLEEP_SOUNDS_OVERRIDE_OTA = "sleep_sounds_override_ota";
     public final static String SLEEP_SEGMENT_OFFSET_REMAPPING = "sleep_segment_offset_remapping";
     public final static String SLEEP_STATS_MEDIUM_SLEEP = "sleep_stats_medium_sleep";

--- a/suripu-coredw/src/main/java/com/hello/suripu/coredw/resources/BaseResource.java
+++ b/suripu-coredw/src/main/java/com/hello/suripu/coredw/resources/BaseResource.java
@@ -141,4 +141,8 @@ public class BaseResource {
     protected Boolean hasSleepSoundsEnabled(final Long accountId) {
         return featureFlipper.userFeatureActive(FeatureFlipper.SLEEP_SOUNDS_ENABLED, accountId, Collections.EMPTY_LIST);
     }
+
+    protected Boolean hasSleepSoundsDisplayFirmwareUpdate(final Long accountId) {
+        return featureFlipper.userFeatureActive(FeatureFlipper.SLEEP_SOUNDS_DISPLAY_FW_UPDATE, accountId, Collections.EMPTY_LIST);
+    }
 }


### PR DESCRIPTION
In the event of another issue like last week where some Senses are unable to communicate with Messeji (which shouldn't happen again, but you never know...), it would be nice to fail more gracefully than either
- your sense just not being connected, so sleep sounds spins forever for you
- us feature flipping you off sleep sounds and totally removing that UI

The idea here is that in case of another "catastrophe", we could blacklist IDs so that people see a nice "you can't use Sleep Sounds while sense is updating" message. Yes it's a hack, but it's a nice, quick, relatively safe system to put in place before we do the Big Launch.

cc @pims @jnorgan @kingshyg @kevintwohy @jimmymlu 
