### PR TITLE
convention use 'last week' for eow

### DIFF
--- a/sql/insights/create_questions.sql
+++ b/sql/insights/create_questions.sql
@@ -529,6 +529,9 @@ UPDATE questions SET responses = S.texts, responses_ids = S.ids FROM (
   (select id from questions order by id DESC LIMIT 3) GROUP BY question_id) AS S
 WHERE questions.id = S.question_id;
 
+--- Update question text grammar consistency
+UPDATE questions SET question_text='How often did you meet last week''s goal?' WHERE question_text='How often did you meet this week''s goal?' AND lang='EN';
+
 
 
 


### PR DESCRIPTION
Updating questions so we always use "last week" at the end of the week when referring to goal delivered at beginning of the week.

Need
- sql run on prod
- ~~sql run on dev~~
