### PR TITLE
Fixing incompatibilities by updating to guava 18 for core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,10 @@
         <dropwizard.version>0.6.2</dropwizard.version>
         <protobuf.version>2.5.0</protobuf.version>
         <aws.sdk.version>1.10.34</aws.sdk.version>
-        <google.guava.version>14.0.1</google.guava.version>
+        <google.guava.version>18.0</google.guava.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
-
         <slf4j.version>1.7.4</slf4j.version>
         <logback.version>1.0.10</logback.version>
         <jackson.version>2.5.3</jackson.version>

--- a/suripu-algorithm/pom.xml
+++ b/suripu-algorithm/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>suripu-algorithm</artifactId>
     <properties>
-        <google.guava.version>14.0.1</google.guava.version>
+        <google.guava.version>18.0</google.guava.version>
     </properties>
     <dependencies>
         <dependency>

--- a/suripu-coredw8/pom.xml
+++ b/suripu-coredw8/pom.xml
@@ -13,9 +13,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>0.8.2</dropwizard.version>
         <metrics.version>3.1.0</metrics.version>
+        <google.guava.version>18.0</google.guava.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${google.guava.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>


### PR DESCRIPTION
Clearing up dependency mismatch seems to fix the problem I am having with suripu-app and the RateLimiter.acquire() method from guava. Was able to repro the issue locally. 

@jakepic1 @kingshyg 
