### PR TITLE
Consistent reads for PushNotificationEventDynamoDB

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/db/TimeSeriesDAODynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/TimeSeriesDAODynamoDB.java
@@ -266,7 +266,7 @@ public abstract class TimeSeriesDAODynamoDB<T> {
     }
 
     //region Query
-    private Response<List<Map<String, AttributeValue>>> query(final QueryRequest originalQueryRequest) {
+    protected Response<List<Map<String, AttributeValue>>> query(final QueryRequest originalQueryRequest) {
         final List<Map<String, AttributeValue>> results = Lists.newArrayList();
 
         Map<String, AttributeValue> lastEvaluatedKey = null;

--- a/suripu-core/src/main/java/com/hello/suripu/core/notifications/PushNotificationEventDynamoDB.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/notifications/PushNotificationEventDynamoDB.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.InternalServerErrorException;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.hello.suripu.core.db.TimeSeriesDAODynamoDB;
@@ -227,6 +228,15 @@ public class PushNotificationEventDynamoDB extends TimeSeriesDAODynamoDB<PushNot
 
         final List<PushNotificationEvent> events = toPushNotificationEventList(response.data);
         return Response.into(events, response);
+    }
+
+    /**
+     * Overridden to ensure consistent reads.
+     */
+    @Override
+    protected Response<List<Map<String, AttributeValue>>> query(final QueryRequest originalQueryRequest) {
+        final QueryRequest consistentQueryRequest = originalQueryRequest.clone().withConsistentRead(true);
+        return super.query(consistentQueryRequest);
     }
 
     public Response<List<PushNotificationEvent>> query(final Long accountId,


### PR DESCRIPTION
Ensure consistent reads are turned on for reading push notifications we've sent from DynamoDB. This way we can make sure we don't send the same notification twice (or multiple notifications that violate our anti-spam constraints).

cc @pims @jnorgan 
