### PR TITLE
standard failover safeguards for neural net

### DIFF
--- a/suripu-core/src/test/java/com/hello/suripu/core/algorithmintegration/NeuralNetAlgTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/algorithmintegration/NeuralNetAlgTest.java
@@ -138,4 +138,25 @@ public class NeuralNetAlgTest extends NeuralNetAlgorithm {
         TestCase.assertEquals(currentTime.getMillis(),resultOptional.get().mainEvents.get(Event.Type.WAKE_UP).getStartTimestamp(),5*DateTimeConstants.MILLIS_PER_MINUTE);
 
     }
+
+
+    @Test
+    public void testDurationSafeguard() throws Exception {
+        DateTime date = DateTimeUtil.ymdStringToDateTime("2015-09-01");
+        DateTime startTime = date.withHourOfDay(18);
+        DateTime endTime = startTime.plusHours(16);
+        DateTime currentTime = startTime.plusHours(2).plusMillis(30);
+
+
+        AllSensorSampleList senseData = OnlineHmmTest.getTypicalDayOfSense(startTime,endTime,0);
+        ImmutableList<TrackerMotion> pillData = OnlineHmmTest.getTypicalDayOfPill(startTime.minusHours(4),endTime.plusHours(4),0);
+        final ImmutableList<TimelineFeedback> emptyFeedback = ImmutableList.copyOf(Lists.<TimelineFeedback>newArrayList());
+        final OneDaysSensorData oneDaysSensorData = new OneDaysSensorData(senseData,pillData,pillData,emptyFeedback,pillData,pillData,date,startTime,endTime,currentTime, DateTimeConstants.MILLIS_PER_HOUR);
+
+        final TimelineLog log = new TimelineLog(0L,0L);
+        final Optional<TimelineAlgorithmResult> resultOptional = getTimelinePrediction(oneDaysSensorData,log,0L,false, Sets.<String>newHashSet());
+
+        TestCase.assertFalse(resultOptional.isPresent());
+
+    }
 }


### PR DESCRIPTION
- I had never added the standard failover tests for the neural net.  
- The error that this actually catches is duration, although it checks for other errors too
- People that got a too-short timeline from the neural net would have gotten and "invalid sleep score" error -- which shows up as not enough data to the user
- Timeline logs indicate that this error has remained pretty constant (around 30 a day, out of ~7000 timelines a day)

So I don't think the impact of this is high, but it should be there anyway.
