### PR TITLE
Fix for expiring password grant access tokens too soon

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/InMemoryOAuthTokenStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/InMemoryOAuthTokenStore.java
@@ -23,7 +23,7 @@ public class InMemoryOAuthTokenStore implements OAuthTokenStore<AccessToken, Cli
     private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryOAuthTokenStore.class);
 
     @Override
-    public AccessToken storeAccessToken(final ClientDetails clientDetails) throws ClientAuthenticationException {
+    public AccessToken storeAccessToken(final ClientDetails clientDetails, final GrantType grantType) throws ClientAuthenticationException {
 
         if(!clientDetails.application.isPresent()) {
             LOGGER.error("Application was not present");

--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/OAuthTokenStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/OAuthTokenStore.java
@@ -1,8 +1,11 @@
 package com.hello.suripu.core.oauth.stores;
 
 import com.google.common.base.Optional;
+
 import com.hello.suripu.core.oauth.ClientAuthenticationException;
+import com.hello.suripu.core.oauth.GrantType;
 import com.hello.suripu.core.oauth.MissingRequiredScopeException;
+
 import org.joda.time.DateTime;
 
 import java.util.UUID;
@@ -21,7 +24,7 @@ import java.util.UUID;
  */
 public interface OAuthTokenStore<T, I, C> {
 
-    T storeAccessToken(I clientDetails) throws ClientAuthenticationException;
+    T storeAccessToken(I clientDetails, GrantType grantType) throws ClientAuthenticationException;
 
     Optional<T> getTokenByClientCredentials(C creds, DateTime now) throws MissingRequiredScopeException;
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/PersistentAccessTokenStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/PersistentAccessTokenStore.java
@@ -6,6 +6,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+
 import com.hello.suripu.core.db.AccessTokenDAO;
 import com.hello.suripu.core.oauth.AccessToken;
 import com.hello.suripu.core.oauth.AccessTokenUtils;
@@ -14,8 +15,10 @@ import com.hello.suripu.core.oauth.ApplicationRegistration;
 import com.hello.suripu.core.oauth.ClientAuthenticationException;
 import com.hello.suripu.core.oauth.ClientCredentials;
 import com.hello.suripu.core.oauth.ClientDetails;
+import com.hello.suripu.core.oauth.GrantType;
 import com.hello.suripu.core.oauth.MissingRequiredScopeException;
 import com.hello.suripu.core.oauth.OAuthScope;
+
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -80,7 +83,7 @@ public class PersistentAccessTokenStore implements OAuthTokenStore<AccessToken, 
      * @throws com.hello.suripu.core.oauth.ClientAuthenticationException
      */
     @Override
-    public AccessToken storeAccessToken(final ClientDetails clientDetails) throws ClientAuthenticationException {
+    public AccessToken storeAccessToken(final ClientDetails clientDetails, final GrantType grantType) throws ClientAuthenticationException {
 
         if(!clientDetails.application.isPresent()) {
             LOGGER.error("ClientDetails should have application for storing access token");
@@ -181,7 +184,6 @@ public class PersistentAccessTokenStore implements OAuthTokenStore<AccessToken, 
                 .withToken(accessTokenUUID)
                 .withRefreshToken(refreshTokenUUID)
                 .withExpiresIn(expirationTimeInSeconds)
-
                 .withCreatedAt(createdAt)
                 .withAccountId(clientDetails.accountId)
                 .withAppId(clientDetails.application.get().id)


### PR DESCRIPTION
Password grant type access tokens should still expire in 1 year, not after 24 hours like code grant tokens. 
@pims 
