### PR TITLE
Using the grant type that already exists in clientdetails

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/InMemoryOAuthTokenStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/InMemoryOAuthTokenStore.java
@@ -23,7 +23,7 @@ public class InMemoryOAuthTokenStore implements OAuthTokenStore<AccessToken, Cli
     private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryOAuthTokenStore.class);
 
     @Override
-    public AccessToken storeAccessToken(final ClientDetails clientDetails, final GrantType grantType) throws ClientAuthenticationException {
+    public AccessToken storeAccessToken(final ClientDetails clientDetails) throws ClientAuthenticationException {
 
         if(!clientDetails.application.isPresent()) {
             LOGGER.error("Application was not present");

--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/OAuthTokenStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/OAuthTokenStore.java
@@ -3,7 +3,6 @@ package com.hello.suripu.core.oauth.stores;
 import com.google.common.base.Optional;
 
 import com.hello.suripu.core.oauth.ClientAuthenticationException;
-import com.hello.suripu.core.oauth.GrantType;
 import com.hello.suripu.core.oauth.MissingRequiredScopeException;
 
 import org.joda.time.DateTime;
@@ -24,7 +23,7 @@ import java.util.UUID;
  */
 public interface OAuthTokenStore<T, I, C> {
 
-    T storeAccessToken(I clientDetails, GrantType grantType) throws ClientAuthenticationException;
+    T storeAccessToken(I clientDetails) throws ClientAuthenticationException;
 
     Optional<T> getTokenByClientCredentials(C creds, DateTime now) throws MissingRequiredScopeException;
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/PersistentAccessTokenStore.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/oauth/stores/PersistentAccessTokenStore.java
@@ -15,7 +15,6 @@ import com.hello.suripu.core.oauth.ApplicationRegistration;
 import com.hello.suripu.core.oauth.ClientAuthenticationException;
 import com.hello.suripu.core.oauth.ClientCredentials;
 import com.hello.suripu.core.oauth.ClientDetails;
-import com.hello.suripu.core.oauth.GrantType;
 import com.hello.suripu.core.oauth.MissingRequiredScopeException;
 import com.hello.suripu.core.oauth.OAuthScope;
 
@@ -83,7 +82,7 @@ public class PersistentAccessTokenStore implements OAuthTokenStore<AccessToken, 
      * @throws com.hello.suripu.core.oauth.ClientAuthenticationException
      */
     @Override
-    public AccessToken storeAccessToken(final ClientDetails clientDetails, final GrantType grantType) throws ClientAuthenticationException {
+    public AccessToken storeAccessToken(final ClientDetails clientDetails) throws ClientAuthenticationException {
 
         if(!clientDetails.application.isPresent()) {
             LOGGER.error("ClientDetails should have application for storing access token");

--- a/suripu-coredw8/src/main/java/com/hello/suripu/coredw8/oauth/stores/PersistentAccessTokenStore.java
+++ b/suripu-coredw8/src/main/java/com/hello/suripu/coredw8/oauth/stores/PersistentAccessTokenStore.java
@@ -88,14 +88,14 @@ public class PersistentAccessTokenStore implements OAuthTokenStore<AccessToken, 
      * @throws com.hello.suripu.core.oauth.ClientAuthenticationException
      */
     @Override
-    public AccessToken storeAccessToken(final ClientDetails clientDetails, final GrantType grantType) throws ClientAuthenticationException {
+    public AccessToken storeAccessToken(final ClientDetails clientDetails) throws ClientAuthenticationException {
 
         if(!clientDetails.application.isPresent()) {
             LOGGER.error("ClientDetails should have application for storing access token");
             throw new ClientAuthenticationException();
         }
 
-        final Long expiration =  (grantType.equals(GrantType.PASSWORD)) ? PASSWORD_GRANT_ACCESS_EXPIRATION_TIME_IN_SECONDS : expirationTimeInSeconds;
+        final Long expiration = (clientDetails.responseType.equals(GrantType.PASSWORD)) ? PASSWORD_GRANT_ACCESS_EXPIRATION_TIME_IN_SECONDS : expirationTimeInSeconds;
 
         final AccessToken accessToken = generateAccessToken(
             clientDetails,


### PR DESCRIPTION
@pims rightly pointed out that passing in the grant type was unnecessary since ClientDetails already had that value. 
