### PR TITLE
jyfan/account questions id mapping

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Question.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Question.java
@@ -184,4 +184,22 @@ public class Question {
                             created, question.category, question.dependencyResponse);
     }
 
+    public static Question withAccountQId(final Question question, final Long accountQuestionId) {
+        return new Question(question.id,
+                            accountQuestionId,
+                            question.text,
+                            question.lang,
+                            question.type,
+                            question.frequency,
+                            question.askTime,
+                            question.dependency,
+                            question.parentId,
+                            question.askLocalDate,
+                            question.choiceList,
+                            question.accountInfo,
+                            question.accountCreationDate,
+                            question.category,
+                            question.dependencyResponse);
+    }
+
 }


### PR DESCRIPTION
Fix for account_questions_id mapping between tables `account_questions` and `responses`.
Previously, questionsResource returned account_questions_id=0 always (rather than the row index of the question saved in account_questions) for both onboarding and survey questions. 

Not a critical fix.
