### PR TITLE
OTA status

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/ota/Status.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/ota/Status.java
@@ -1,0 +1,10 @@
+package com.hello.suripu.core.ota;
+
+public enum Status {
+
+    NOT_REQUIRED,
+    REQUIRED,
+    IN_PROGRESS,
+    COMPLETE,
+    ERROR;
+}


### PR DESCRIPTION
During onboarding, user might need to OTA their Sense. Mobile clients can use this status to trigger the OTA manually.

cc @jimmymlu @jnorgan 
