### PR TITLE
removed min value threshold for duration score

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/SleepScoreUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/SleepScoreUtils.java
@@ -175,9 +175,7 @@ public class SleepScoreUtils {
         //Adjusted sleep duration based on deviations from population mean, reduced magnitude of delta
         adjSleepDurationV3 = sleepDurationMinutes + (DURATION_POP_IDEAL - sleepDurationTargetV3)/2;
 
-        if (adjSleepDurationV3 < DURATION_MIN_V3) {
-            rawScoreV3 = RAW_SCORE_MIN_V3;
-        }else if (adjSleepDurationV3 > DURATION_MAX_V3) {
+        if (adjSleepDurationV3 > DURATION_MAX_V3) {
             rawScoreV3 = RAW_SCORE_MAX_DUR_V3;
         }else{
             //rawScore calculated using 5th degree polynomial model to extrapolate change in sleep quality with sleep duration
@@ -197,7 +195,7 @@ public class SleepScoreUtils {
         final int maxTimesAwake = 6;
         final int maxAgitatedSleep = 45;
         final float rawScore = DURATION_WEIGHTS_V4[0] + DURATION_WEIGHTS_V4[1] * sleepDurationScoreV3 + DURATION_WEIGHTS_V4[2] * Math.min(agitatedSleepDuration, maxAgitatedSleep) + DURATION_WEIGHTS_V4[3] * Math.min(motionFrequency.motionFrequencyFirstPeriod, maxMotionFreq)  + DURATION_WEIGHTS_V4[4] * Math.min( motionFrequency.motionFrequencyMiddlePeriod, maxMotionFreq) + DURATION_WEIGHTS_V4[5] * Math.min(motionFrequency.motionFrequencyLastPeriod, maxMotionFreq) + DURATION_WEIGHTS_V4[6] * Math.min(timesAwake, maxTimesAwake);
-        final int durationScorev4 = (int) Math.max(Math.min(rawScore * .95 + 21, 90), 40);
+        final int durationScorev4 = (int) Math.max(Math.min(rawScore * .95 + 21, 90), 0);
         LOGGER.trace("action=calculated-durationscore-v4 account_id={} sleep_duration_score_v3={} motion_frequency={} awake_times={} agitated_sleep_duration={} durationscore_v4={}", accountId, sleepDurationScoreV3, motionFrequency.motionFrequency, timesAwake, agitatedSleepDuration, durationScorev4);
         return durationScorev4;
     }

--- a/suripu-core/src/test/java/com/hello/suripu/core/util/SleepScoreUtilsTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/SleepScoreUtilsTest.java
@@ -72,7 +72,7 @@ public class SleepScoreUtilsTest {
         final int age = 23;
         final int durThreshold = 540;
         final List<Integer> sleepDurationMinutes = Lists.newArrayList(80, 299, 360, 510, 780);
-        final List<Float> correct = Lists.newArrayList(39.32f, 43.685326f, 46.401653f, 55.010803f, 52.866f);
+        final List<Float> correct = Lists.newArrayList(30.469934F, 43.685326f, 46.401653f, 55.010803f, 52.866f);
         for (int i = 0; i < sleepDurationMinutes.size(); i++) {
             final float score = SleepScoreUtils.getSleepScoreDurationV3(age, durThreshold, sleepDurationMinutes.get(i));
             LOGGER.info("value {} -> {}", sleepDurationMinutes.get(i), score);
@@ -85,7 +85,7 @@ public class SleepScoreUtilsTest {
         final int age = 23;
         final int durThreshold = 0;
         final List<Integer> sleepDurationMinutes = Lists.newArrayList(80, 299, 360, 510, 780);
-        final List<Float> correct = Lists.newArrayList(39.32f, 44.867283f, 48.128555f, 56.04506f, 52.866f);
+        final List<Float> correct = Lists.newArrayList(35.587597F, 44.867283f, 48.128555f, 56.04506f, 52.866f);
         for (int i = 0; i < sleepDurationMinutes.size(); i++) {
             final float score = SleepScoreUtils.getSleepScoreDurationV3(age, durThreshold, sleepDurationMinutes.get(i));
             LOGGER.info("value {} -> {}", sleepDurationMinutes.get(i), score);
@@ -103,6 +103,15 @@ public class SleepScoreUtilsTest {
         assertThat(testDurScoreV4, is(77));
     }
 
+    @Test
+    public void testScoresV4MinScore(){
+        final float testDurScoreV3 = 25;
+        final MotionFrequency testMotionFreq = new MotionFrequency(0.673f,  0.673f, 0.0f, 0.673f);
+        final int testTimesAwake = 1;
+        final int testAgitatedSleepDuration = 0;
+        final int testDurScoreV4 = SleepScoreUtils.getSleepScoreDurationV4(1001L, testDurScoreV3, testMotionFreq, testTimesAwake, testAgitatedSleepDuration);
+        assertThat(testDurScoreV4, is(0));
+    }
 
     private List<TrackerMotion> trackerMotionList(String fixturePath) {
         final URL fixtureCSVFile = Resources.getResource(fixturePath);


### PR DESCRIPTION
Issue: User can 'correct' timeline and sleep duration down to 0 mins of sleep, yet the returned score is the min score (40 for duration).  Lower than 180 mins for natural time line defaults to 0. 

Fix: Lowered the min possible duration score to 0. 

• set min duration score to 0, 
• added min sleep duration score test

Results: 
• Slight decrease expected in v4 and v2 score diff.
• Minor decrease  (<.003) in correlation with sleep quality.
• If user corrects their timeline to short durations, their score can now go down to zero. 
