### PR TITLE
renaming and returning intent status

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/Intent.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/Intent.java
@@ -3,33 +3,33 @@ package com.hello.suripu.core.swap;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-public class SwapIntent {
+public class Intent {
 
     private final String currentSenseId;
     private final String newSenseId;
     private final Long accountId;
     private final DateTime dateTime;
 
-    private SwapIntent(final String currentSenseId, final String newSenseId, final Long accountId, final DateTime dateTime) {
+    private Intent(final String currentSenseId, final String newSenseId, final Long accountId, final DateTime dateTime) {
         this.currentSenseId = currentSenseId;
         this.newSenseId = newSenseId;
         this.accountId = accountId;
         this.dateTime = dateTime;
     }
 
-    public static SwapIntent create(
+    public static Intent create(
             final String currentSenseId,
             final String newSenseId,
             final Long accountId) {
-        return new SwapIntent(currentSenseId, newSenseId, accountId, DateTime.now(DateTimeZone.UTC));
+        return new Intent(currentSenseId, newSenseId, accountId, DateTime.now(DateTimeZone.UTC));
     }
 
-    public static SwapIntent create(
+    public static Intent create(
             final String currentSenseId,
             final String newSenseId,
             final Long accountId,
             final DateTime dateTime) {
-        return new SwapIntent(currentSenseId, newSenseId, accountId, dateTime);
+        return new Intent(currentSenseId, newSenseId, accountId, dateTime);
     }
 
     public String newSenseId() {

--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/IntentResult.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/IntentResult.java
@@ -1,0 +1,33 @@
+package com.hello.suripu.core.swap;
+
+import com.google.common.base.Optional;
+
+public class IntentResult {
+
+    final private Optional<Intent> swapIntent;
+    final private Status status;
+
+    private IntentResult(final Optional<Intent> swapIntent, final Status status) {
+        this.swapIntent = swapIntent;
+        this.status = status;
+    }
+
+    public static IntentResult ok(final Intent intent) {
+        return new IntentResult(Optional.of(intent), Status.OK);
+    }
+
+    public static IntentResult failed(final Status status) {
+        if(status == Status.OK) {
+            throw new IllegalArgumentException(String.format("status invalid: %s", status));
+        }
+        return new IntentResult(Optional.<Intent>absent(), status);
+    }
+
+    public Optional<Intent> intent() {
+        return swapIntent;
+    }
+
+    public Status status() {
+        return status;
+    }
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/Request.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/Request.java
@@ -3,17 +3,17 @@ package com.hello.suripu.core.swap;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class SwapRequest {
+public class Request {
 
     final private String senseId;
 
-    private SwapRequest(String senseId) {
+    private Request(String senseId) {
         this.senseId = senseId;
     }
 
     @JsonCreator
-    public static SwapRequest create(@JsonProperty("sense_id") final String senseId) {
-        return new SwapRequest(senseId);
+    public static Request create(@JsonProperty("sense_id") final String senseId) {
+        return new Request(senseId);
     }
 
     public String senseId() {

--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/Response.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/Response.java
@@ -1,0 +1,21 @@
+package com.hello.suripu.core.swap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Response {
+
+    private final Status status;
+
+    private Response(Status status) {
+        this.status = status;
+    }
+
+    public static Response create(Status status) {
+        return new Response(status);
+    }
+
+    @JsonProperty("status")
+    public Status status() {
+        return status;
+    }
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/Result.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/Result.java
@@ -4,7 +4,7 @@ import com.google.common.base.Optional;
 
 ;
 
-public class SwapResult {
+public class Result {
 
     private final boolean successful;
     private final Optional<Error> error;
@@ -15,17 +15,17 @@ public class SwapResult {
         SOMETHING_ELSE;
     }
 
-    public SwapResult(boolean successful, Optional<Error> error) {
+    public Result(boolean successful, Optional<Error> error) {
         this.successful = successful;
         this.error = error;
     }
 
-    public static SwapResult failed(Error error) {
-        return new SwapResult(false, Optional.of(error));
+    public static Result failed(Error error) {
+        return new Result(false, Optional.of(error));
     }
 
-    public static SwapResult success() {
-        return new SwapResult(true, Optional.<Error>absent());
+    public static Result success() {
+        return new Result(true, Optional.<Error>absent());
     }
 
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/Status.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/Status.java
@@ -1,0 +1,8 @@
+package com.hello.suripu.core.swap;
+
+public enum Status {
+    OK,
+    ACCOUNT_PAIRED_TO_MULTIPLE_SENSE,
+
+    NEW_SENSE_PAIRED_TO_DIFFERENT_ACCOUNT;
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/swap/Swapper.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/swap/Swapper.java
@@ -3,9 +3,9 @@ package com.hello.suripu.core.swap;
 import com.google.common.base.Optional;
 
 public interface Swapper {
-    SwapResult swap(SwapIntent intent);
-    void create(SwapIntent intent);
-    Optional<SwapIntent> query(String senseId);
-    Optional<SwapIntent> query(String senseId, int minutesAgo);
-    Optional<SwapIntent> eligible(Long accountId, String senseId);
+    Result swap(Intent intent);
+    void create(Intent intent);
+    Optional<Intent> query(String senseId);
+    Optional<Intent> query(String senseId, int minutesAgo);
+    IntentResult eligible(Long accountId, String senseId);
 }

--- a/suripu-core/src/test/java/com/hello/suripu/core/swap/ddb/DynamoDBSwapperIT.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/swap/ddb/DynamoDBSwapperIT.java
@@ -19,8 +19,9 @@ import com.google.common.collect.Lists;
 import com.hello.suripu.core.db.DeviceDAO;
 import com.hello.suripu.core.db.MergedUserInfoDynamoDB;
 import com.hello.suripu.core.models.DeviceAccountPair;
-import com.hello.suripu.core.swap.SwapIntent;
-import com.hello.suripu.core.swap.SwapResult;
+import com.hello.suripu.core.swap.Intent;
+import com.hello.suripu.core.swap.IntentResult;
+import com.hello.suripu.core.swap.Result;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -114,14 +115,14 @@ public class DynamoDBSwapperIT {
 
         when(deviceDAO.getSensesForAccountId(accountId)).thenReturn(pairs);
         when(deviceDAO.getAccountIdsForDeviceId(newSenseId)).thenReturn(ImmutableList.<DeviceAccountPair>of());
-        final Optional<SwapIntent> intent = swapper.eligible(accountId, newSenseId);
-        assertTrue(intent.isPresent());
-        swapper.create(intent.get());
+        final IntentResult intentResult = swapper.eligible(accountId, newSenseId);
+        assertTrue(intentResult.intent().isPresent());
+        swapper.create(intentResult.intent().get());
 
-        final Optional<SwapIntent> swapIntent = swapper.query(newSenseId);
+        final Optional<Intent> swapIntent = swapper.query(newSenseId);
         assertTrue(swapIntent.isPresent());
-        final SwapResult swapResult = swapper.swap(swapIntent.get());
-        assertTrue(swapResult.successful());
+        final Result result = swapper.swap(swapIntent.get());
+        assertTrue(result.successful());
 
         final ItemCollection<QueryOutcome> foo = mergedTable.query(
                 "device_id", newSenseId,


### PR DESCRIPTION
This is to support returning detailed errors to the client when initiating the swap request.

⚠️ Will break service since API changes are not backward compatible.
