### PR TITLE
Sleep debt log fix 2

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/SleepDeprivation.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/SleepDeprivation.java
@@ -27,6 +27,8 @@ public class SleepDeprivation {
     private static final int N_HISTORIC_NIGHTS = 28;
     private static final int MIN_N_HISTORIC_NIGHTS = 14; //minimal number of nights to calculate avg sleep dur
     private static final int DURATION_DIFF_THRESHOLD = 60; //minimal difference between avg deprived sleep and avg sleep for user
+    private static final int MIN_AGE = 18;
+    private static final int MAX_AGE = 90;
 
     public static Optional<InsightCard> getInsights(final SleepStatsDAODynamoDB sleepStatsDAODynamoDB, final AccountReadDAO accountReadDAO, final Long accountId, final boolean hasSleepDeprivationInsight) {
         //ideal sleep duration
@@ -42,7 +44,7 @@ public class SleepDeprivation {
 
         final int userAge = DateTimeUtil.getDateDiffFromNowInDays(optionalAccount.get().DOB) / 365;
 
-        if (userAge < 18 || userAge > 90){
+        if (userAge < MIN_AGE || userAge > MAX_AGE){
             return Optional.absent();
         }
 

--- a/suripu-core/src/test/java/com/hello/suripu/core/processors/insights/SleepDeprivationInsightsTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/processors/insights/SleepDeprivationInsightsTest.java
@@ -132,8 +132,11 @@ public class SleepDeprivationInsightsTest {
         Mockito.when(sleepStatsDAODynamoDB.getBatchStats(FAKE_ACCOUNT_ID, testQueryStartDate1,testQueryEndDate1)).thenReturn(ImmutableList.copyOf(fakeAggregateSleepStatsList1));
         Mockito.when(sleepStatsDAODynamoDB.getBatchStats(FAKE_ACCOUNT_ID,testQueryStartDate2, testQueryEndDate2)).thenReturn(ImmutableList.copyOf(fakeAggregateSleepStatsList2));
         Mockito.when(accountReadDAO.getById(FAKE_ACCOUNT_ID)).thenReturn(Optional.of(fakeAccount));
+        Mockito.when(sleepStatsDAODynamoDB.getTimeZoneOffset(FAKE_ACCOUNT_ID)).thenReturn(Optional.<Integer>absent());
 
-        final Optional<InsightCard> insightGenerated = SleepDeprivation.getInsights(sleepStatsDAODynamoDB, accountReadDAO, FAKE_ACCOUNT_ID, FAKE_TIMESTAMP, true);
+        final int testMeanSleepDebt = 190;
+
+        final Optional<InsightCard> insightGenerated = SleepDeprivation.getInsights(sleepStatsDAODynamoDB, accountReadDAO, FAKE_ACCOUNT_ID, true);
         assertThat(insightGenerated.isPresent(), is(Boolean.FALSE));
     }
 


### PR DESCRIPTION
Fixed log message to return meanSleepDuration for sleep deprived nights and the previous 4 weeks.
