### PR TITLE
impose co2 lower bound

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/util/calibration/SenseOneFiveDataConversion.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/calibration/SenseOneFiveDataConversion.java
@@ -103,8 +103,8 @@ public class SenseOneFiveDataConversion {
 
     //returns units in ppm
     public static float convertRawToCO2(final int co2Raw) {
-        if (co2Raw <= 0) {
-            return 0.0f;
+        if (co2Raw <= 400) {
+            return 400.0f; //400ppm lower bound is imposed by manufac, but we can report 0 at startup before sensor is ready
         }
 
         return (float) co2Raw;


### PR DESCRIPTION
In this PR:
- We impose a lower bound of 400 ppm for CO2. This limit is actually imposed by the manufacturer, but we report 0 values temporarily after OTAs before the sensor starts reporting real values. Without this PR, users would see plots like below
![coo1006_2016-11-01ma 1scale 1 0](https://cloud.githubusercontent.com/assets/3487385/19908610/51d008fc-a041-11e6-9988-3c8129a94ff8.png)
We decided to place this lower bound in the backend rather than FW for now to control FW changes at launch time.

Related:
1. We no longer observe in the office units one of the data anomalies observed before FW fix (compensation with temperature and humidity) discontinuities where CO2 and VOC would drop suddenly to 400ppm. 
2. We no longer observe in the office units one of the data anomalies observed before FW fix where we had values > 5000ppm. Note that we still do observe quite high values of up to 3500 ppm (see below), but while this is very high (values are unlikely), it could be explained by extra VOCs or particularly poor ventilation (values are not impossible). We decided against backend scaling or compensation for now, but want to continue to monitor this sensor.
![coo1072_2016-11-01ma 1scale 1 0](https://cloud.githubusercontent.com/assets/3487385/19908791/08c42bb0-a042-11e6-8f86-1fb703af82b9.png)
3. Through an in-office test of 2 units (1 burned in and the other not burned in) we determined that the lack of factory burn-in did not significantly affect data reported around start-up time. This is further evidence that we should not tamper with data in the backend. Both units consistently reported data around 500 ppm (true value) and below 1000 ppm.
![blah](https://cloud.githubusercontent.com/assets/3487385/19908887/6ab6a8f2-a042-11e6-85b7-32e449fb7c66.png)

