### PR TITLE
Fix for same alarm time expansion bug

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Alarm.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Alarm.java
@@ -565,6 +565,11 @@ public class Alarm {
             final List<AlarmExpansion> expansions = Lists.newArrayList();
 
             for(final Alarm alarm: alarmList){
+
+                if(!alarm.isEnabled) {
+                    continue;
+                }
+
                 if(alarm.expansions.isEmpty()) {
                     continue;
                 }


### PR DESCRIPTION
Fixed case where a disabled alarm's expansions got applied to an enabled alarm at same time.

@pims 