### PR TITLE
[DO NOT MERGE WIP] jyfan/strict-alarm

### DIFF
--- a/sql/insights/create_questions.sql
+++ b/sql/insights/create_questions.sql
@@ -696,6 +696,126 @@ UPDATE questions SET dependency_response=(SELECT ARRAY_AGG(id) FROM response_cho
     WHERE question_text=ANY(ARRAY['How noticeable do you think the effects of your difficulty sleeping are to other people?',
                                   'How much does your difficulty sleeping interfere with the rest of your day? (e.g. daytime fatigue, mood, concentration, memory, mood, etc.)']);
 
+-- jyfan 2016-10-31 strict alarm questions
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 6:00 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 6:30 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 7:00 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 7:30 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 8:00 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 8:30 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 9:00 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 9:30 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO questions (question_text, lang, frequency, response_type, responses, dependency, ask_time, category)
+  VALUES (
+      'You could benefit from a consistent wake time. Set a recurring alarm for 10:00 AM? Existing alarms will be deleted.', -- text
+      'EN', -- lang
+      'trigger', -- frequency (note, trigger is currently not implemented in QuestionProcessor)
+      'choice', --response_type,
+      '{"Yes", "No", "No, this time doesn''t work"}', --text responses
+      null, -- dependency
+      'anytime', -- ask_time
+      'insight' --category
+);
+
+INSERT INTO response_choices (question_id, response_text)
+    (SELECT id, UNNEST(responses) FROM questions WHERE id IN (SELECT id FROM questions ORDER BY id DESC LIMIT 9));
+
+UPDATE questions SET responses = S.texts, responses_ids = S.ids FROM (
+  SELECT question_id, ARRAY_AGG(id) AS ids, ARRAY_AGG(response_text) AS texts
+  FROM response_choices where question_id IN
+  (select id from questions order by id DESC LIMIT 9) GROUP BY question_id) AS S
+WHERE questions.id = S.question_id;
+
+
+
 
 
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/InsightCard.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/InsightCard.java
@@ -51,7 +51,8 @@ public class InsightCard implements Comparable<InsightCard> {
         GOAL_SCHEDULE_THOUGHTS(33),
         GOAL_SCREENS(34),
         GOAL_WAKE_VARIANCE(35),
-        SLEEP_DEPRIVATION(36);
+        SLEEP_DEPRIVATION(36),
+        STRICT_ALARM(37);
 
         private int value;
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/QuestionCard.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Insights/QuestionCard.java
@@ -1,0 +1,30 @@
+package com.hello.suripu.core.models.Insights;
+
+import org.joda.time.DateTime;
+
+/**
+ * Created by jyfan on 11/7/16.
+ */
+public class QuestionCard {
+    public Long accountId;
+    public Integer questionId;
+    public DateTime startDate;
+    public DateTime expireDate;
+
+    private QuestionCard(final Long accountId,
+                        final Integer questionId,
+                        final DateTime startDate,
+                        final DateTime expireDate) {
+        this.accountId = accountId;
+        this.questionId = questionId;
+        this.startDate = startDate;
+        this.expireDate = expireDate;
+    }
+
+    public static QuestionCard createQuestionCard(final Long accountId,
+                                                 final Integer questionId,
+                                                 final DateTime startDate,
+                                                 final DateTime expireDate) {
+        return new QuestionCard(accountId, questionId, startDate, expireDate);
+    }
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/models/Questions/QuestionCategory.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/Questions/QuestionCategory.java
@@ -11,7 +11,8 @@ public enum QuestionCategory {
     ANOMALY_LIGHT("anomaly_light"),
     GOAL_GO_OUTSIDE("goal_go_outside"),
     GOAL("goal"),
-    SURVEY("survey");
+    SURVEY("survey"),
+    INSIGHT("insight"); //paired with insight, should be 1st priority
 
     private String value;
 

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/QuestionSurveyProcessor.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/QuestionSurveyProcessor.java
@@ -122,7 +122,6 @@ public class QuestionSurveyProcessor {
     /*
     Insert questions
      */
-
     private void saveQuestion(final Long accountId, final Question question, final DateTime todayLocal, final DateTime expireDate) {
         LOGGER.debug("action=saved_question processor=question_survey account_id={} question_id={} today_local={} expire_date={}", accountId, question.id, todayLocal, expireDate);
         this.questionResponseDAO.insertAccountQuestion(accountId, question.id, todayLocal, expireDate);

--- a/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/StrictAlarm.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/processors/insights/StrictAlarm.java
@@ -1,0 +1,148 @@
+package com.hello.suripu.core.processors.insights;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
+import com.hello.suripu.core.models.AggregateSleepStats;
+import com.hello.suripu.core.models.Insights.InsightCard;
+import com.hello.suripu.core.models.Insights.QuestionCard;
+import com.hello.suripu.core.processors.InsightProcessor;
+import com.hello.suripu.core.util.DateTimeUtil;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by jyfan on 10/31/16.
+ */
+public class StrictAlarm {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WakeVariance.class);
+    private static final int NUM_DAYS_ONE_WEEK = 7;
+
+    public static Optional<QuestionCard> getQuestion(final SleepStatsDAODynamoDB sleepStatsDAODynamoDB, final Long accountId, final DateTime queryEndDate, final int numDays, final Map<String, Integer> strictAlarmTextQidMap) {
+
+        //get wake variance data for the past n=numDays days
+        final DateTime queryStartDate = queryEndDate.minusDays(numDays);
+        final String queryEndDateString = DateTimeUtil.dateToYmdString(queryEndDate);
+        final String queryStartDateString = DateTimeUtil.dateToYmdString(queryStartDate);
+
+        final List<AggregateSleepStats> sleepStats = sleepStatsDAODynamoDB.getBatchStats(accountId, queryStartDateString, queryEndDateString);
+        LOGGER.debug("insight=wake-variance sleep_stat_len={} account_id={}", sleepStats.size(), accountId);
+        final List<Integer> wakeTimeList = Lists.newArrayList();
+        final List<Integer> weekdayWakeTimeList = Lists.newArrayList();
+        for (final AggregateSleepStats stat : sleepStats) {
+
+            final Long wakeTimeStamp = stat.sleepStats.wakeTime;
+            final DateTime wakeTimeDateTime = new DateTime(wakeTimeStamp, DateTimeZone.forOffsetMillis(stat.offsetMillis));
+            final int wakeTime = wakeTimeDateTime.getMinuteOfDay();
+            wakeTimeList.add(wakeTime);
+
+            final int dayOfWeek = wakeTimeDateTime.getDayOfWeek();
+            if (dayOfWeek < 5) { //if weekday (exclude friday night/sat morning)
+                weekdayWakeTimeList.add(wakeTime);
+            }
+
+        }
+
+        final Boolean qualifyInsight = qualifyStrictAlarm(wakeTimeList);
+        if (!qualifyInsight) {
+            return Optional.absent();
+        }
+
+        if (weekdayWakeTimeList.isEmpty()) {
+            return Optional.absent();
+        }
+
+        //calculate target wake time
+        final Integer recWeekdayWakeMins = getRecommendedWakeMinutes(weekdayWakeTimeList);
+        final Optional<Integer> recQidOptional = mapWakeTimeToQid(recWeekdayWakeMins, strictAlarmTextQidMap);
+
+        if (!recQidOptional.isPresent()) {
+            return Optional.absent();
+        }
+
+        final Integer offsetMillis = sleepStats.get(0).offsetMillis;
+        final DateTime todayLocal = DateTime.now(DateTimeZone.UTC).plusMillis(offsetMillis).withTimeAtStartOfDay();
+        final DateTime expireDate = todayLocal.plusDays(NUM_DAYS_ONE_WEEK);
+
+        return Optional.of(QuestionCard.createQuestionCard(accountId, recQidOptional.get(), todayLocal, expireDate));
+    }
+
+    public static Boolean qualifyStrictAlarm(final List<Integer> wakeTimeList) {
+
+        if (wakeTimeList.isEmpty() || wakeTimeList.size() <=2) {
+            return Boolean.FALSE; //not big enough to calculate variance usefully
+        }
+
+        // compute variance
+        final DescriptiveStatistics stats = new DescriptiveStatistics();
+        for (final int wakeTime : wakeTimeList) {
+            stats.addValue(wakeTime);
+        }
+
+        final Double wakeStdDevDouble = stats.getStandardDeviation();
+        final int wakeStdDev = (int) Math.round(wakeStdDevDouble);
+
+        if (wakeStdDev >= 90) { //1.5 hours
+            return Boolean.TRUE;
+        }
+
+        return Boolean.FALSE;
+    }
+
+    public static Integer getRecommendedWakeMinutes(final List<Integer> weekdayWakeTimeList) {
+
+        final DescriptiveStatistics stats = new DescriptiveStatistics();
+        for (final int wakeTime : weekdayWakeTimeList) {
+            stats.addValue(wakeTime);
+        }
+
+        final int avgWeekdayWake = (int) stats.getMean();
+
+        return avgWeekdayWake;
+    }
+
+    public static Optional<Integer> mapWakeTimeToQid(final Integer recommendedWakeTimeMins, final Map<String, Integer> textQidMap) {
+
+        final String questionText;
+
+        if (recommendedWakeTimeMins < 360) { //6AM
+            questionText = "nonexistent question";
+        } else if (recommendedWakeTimeMins < 375) { //6:30AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 6:00 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 405) { //6:45AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 6:30 AM? Existing alarms will be deleted."; //TODO edit to real time
+        } else if (recommendedWakeTimeMins < 435) { //7:15AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 7:00 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 465) { //7:45AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 7:30 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 495) { //8:15AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 8:00 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 525) { //8:45AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 8:30 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 555) { //9:15AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 9:00 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 585) { //9:45AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 9:30 AM? Existing alarms will be deleted.";
+        } else if (recommendedWakeTimeMins < 630) { //10:30AM
+            questionText = "You could benefit from a consistent wake time. Set a recurring alarm for 10:00 AM? Existing alarms will be deleted.";
+        } else {
+            questionText = "nonexistent question";
+        }
+
+        final Integer qid = textQidMap.get(questionText);
+        if (qid == null) {
+            return Optional.absent();
+        }
+
+        return Optional.of(qid);
+    }
+
+
+}

--- a/suripu-core/src/main/java/com/hello/suripu/core/util/QuestionUtils.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/util/QuestionUtils.java
@@ -21,16 +21,18 @@ public class QuestionUtils {
             public Integer apply(Question question) {
                 if (question.category.equals(QuestionCategory.ONBOARDING)) {
                     return 0;
-                } if (question.category.equals(QuestionCategory.ANOMALY_LIGHT)) {
+                } if (question.category.equals(QuestionCategory.INSIGHT)) {
                     return 1;
-                } if (question.category.equals(QuestionCategory.DAILY)) {
+                } if (question.category.equals(QuestionCategory.ANOMALY_LIGHT)) {
                     return 2;
-                } if (question.category.equals(QuestionCategory.GOAL)) {
+                } if (question.category.equals(QuestionCategory.DAILY)) {
                     return 3;
-                } if (question.category.equals(QuestionCategory.SURVEY)) {
+                } if (question.category.equals(QuestionCategory.GOAL)) {
                     return 4;
-                } else {
+                } if (question.category.equals(QuestionCategory.SURVEY)) {
                     return 5;
+                } else {
+                    return 6;
                 }
             }
         };

--- a/suripu-core/src/test/java/com/hello/suripu/core/processors/InsightProcessorTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/processors/InsightProcessorTest.java
@@ -13,6 +13,8 @@ import com.hello.suripu.core.db.DeviceDAO;
 import com.hello.suripu.core.db.DeviceDataDAODynamoDB;
 import com.hello.suripu.core.db.InsightsDAODynamoDB;
 import com.hello.suripu.core.db.MarketingInsightsSeenDAODynamoDB;
+import com.hello.suripu.core.db.QuestionResponseDAO;
+import com.hello.suripu.core.db.QuestionResponseReadDAO;
 import com.hello.suripu.core.db.SleepStatsDAODynamoDB;
 import com.hello.suripu.core.db.TrendsInsightsDAO;
 import com.hello.suripu.core.db.responses.Response;
@@ -150,6 +152,8 @@ public class InsightProcessorTest {
         final CalibrationDAO calibrationDAO = Mockito.mock(CalibrationDAO.class);
         final AccountInfoProcessor accountInfoProcessor = Mockito.mock(AccountInfoProcessor.class);
         final MarketingInsightsSeenDAODynamoDB marketingInsightsSeenDAODynamoDB = Mockito.mock(MarketingInsightsSeenDAODynamoDB.class);
+        final QuestionResponseDAO questionResponseDAO = Mockito.mock(QuestionResponseDAO.class);
+        final Map<String, Integer> strictAlarmTextQidMap = new HashMap<>();
 
         //Prepping for taking care of @NotNull check for light
         final int light = 2;
@@ -244,7 +248,9 @@ public class InsightProcessorTest {
                 lightData,
                 wakeStdDevData,
                 calibrationDAO,
-                marketingInsightsSeenDAODynamoDB);
+                marketingInsightsSeenDAODynamoDB,
+                questionResponseDAO,
+                strictAlarmTextQidMap);
 
         //only to get rid of null pointer exception
         final InsightCard insightCardMock = Mockito.mock(InsightCard.class);

--- a/suripu-core/src/test/java/com/hello/suripu/core/util/SenseOneFiveDataConversionTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/SenseOneFiveDataConversionTest.java
@@ -33,7 +33,7 @@ public class SenseOneFiveDataConversionTest {
     final float ALERT_CO2_HIGH = 1200;
 
     final float ALERT_UV_HIGH = 2;
-
+    
     @Test
     public void testRGBtoLux_one() throws IOException {
         final float LUXMETER_GOLDSTANDARD_MIN = 500;


### PR DESCRIPTION
In this PR:
- Asks user for consent to set a single alarm clock
- Current condition: User wake variance is above some threshold. User has enough sleep stats during the week to figure out an average wake up time

To change:
- Change condition to: User has different alarms set for weekdays and weekend. User has enough sleep stats during the week to figure out an average wake up time.
- Test questions UI

More implementation:
- Testing on admin insight endpoint
- Immediately set alarm in response endpoint 
- Scheduling "insight" under feature flipper