### PR TITLE
lowered thresholds for progressive smart alarm

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/models/ProgressiveAlarmThresholds.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/models/ProgressiveAlarmThresholds.java
@@ -16,7 +16,7 @@ public class ProgressiveAlarmThresholds {
     private final static int AMPLITUDE_DECAY_RATE =  267; // amplitude threshold decays to 500 with 15 minutes left
     private final static float AMPLITUDE_COUNT_DECAY_RATE =  0.07f; // required count decays to 1 with 15 minutes left
     private final static float ON_DURATION_DECAY_RATE = 0.45f; //od threshold decays to 2 with 15 minutes left.
-    private final static int AMPLITUDE_MIN_THRESHOLD = 400;
+    private final static int AMPLITUDE_MIN_THRESHOLD = 0;
     private final static int ON_DURATION_MIN_THRESHOLD = 2;
     private final static int KICKOFF_COUNT_MIN_THREHSOLD = 2;
     private final static int AMPLITUDE_MIN_COUNT = 1;

--- a/suripu-core/src/test/java/com/hello/suripu/core/processors/RingTimeProcessorTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/processors/RingTimeProcessorTest.java
@@ -536,7 +536,7 @@ public class RingTimeProcessorTest {
 
         currentTime = currentTime + 6 * DateTimeConstants.MILLIS_PER_MINUTE;
         progressiveThreshold = ProgressiveAlarmThresholds.getDecayingThreshold(currentTime, ringTime, true);
-        assertThat(progressiveThreshold.amplitudeThreshold, is(400));
+        assertThat(progressiveThreshold.amplitudeThreshold, is(228));
         assertThat(progressiveThreshold.amplitudeThresholdCountLimit, is(1));
         assertThat(progressiveThreshold.kickoffCountThreshold, is(2));
         assertThat(progressiveThreshold.onDurationThreshold, is(2));


### PR DESCRIPTION
Changed decaying thresholds go into effect earlier and decay faster. 
Progressive smart alarm reaches minimal thresholds ~ 15 mins before scheduled alarm (so it takes into account all motion 22 minutes before the scheduled alarm). 
Amplitude threshold is reduced to 400
Amplitude count is reduced to 1
on duration is reduced to 2
Kickoff count is reduced to 2


