### PR TITLE
moved FF implementation to computeStats

### DIFF
--- a/suripu-core/src/test/java/com/hello/suripu/core/util/TimelineUtilsTest.java
+++ b/suripu-core/src/test/java/com/hello/suripu/core/util/TimelineUtilsTest.java
@@ -84,7 +84,7 @@ public class TimelineUtilsTest {
         final List<Event> greyEvents = timelineUtils.greyNullEventsOutsideBedPeriod(cleanedUpEvents, sleep, wake);
         final List<Event> nonSignificantFilteredEvents = timelineUtils.removeEventBeforeSignificant(greyEvents);
         final List<SleepSegment> sleepSegments = timelineUtils.eventsToSegments(nonSignificantFilteredEvents);
-        final SleepStats sleepStats = TimelineUtils.computeStats(sleepSegments, trackerMotions, 70, true);
+        final SleepStats sleepStats = TimelineUtils.computeStats(sleepSegments, trackerMotions, 70, true, true);
         final Integer uninterruptedDuration = 380;
         assertThat(sleepStats.uninterruptedSleepDurationInMinutes, is(uninterruptedDuration));
     }

--- a/suripu-coredropwizard/src/main/java/com/hello/suripu/coredropwizard/timeline/InstrumentedTimelineProcessor.java
+++ b/suripu-coredropwizard/src/main/java/com/hello/suripu/coredropwizard/timeline/InstrumentedTimelineProcessor.java
@@ -722,7 +722,9 @@ public class InstrumentedTimelineProcessor extends FeatureFlippedProcessor {
         final List<SleepSegment> sleepSegments = timelineUtils.eventsToSegments(nonSignificantFilteredEvents);
 
         final int lightSleepThreshold = 70; // TODO: Generate dynamically instead of hard threshold
-        final SleepStats sleepStats = timelineUtils.computeStats(sleepSegments, trackerMotions, lightSleepThreshold, hasSleepStatMediumSleep(accountId));
+        final boolean useUninterruptedDuration = useUninterruptedDuration(accountId);
+
+        final SleepStats sleepStats = timelineUtils.computeStats(sleepSegments, trackerMotions, lightSleepThreshold, hasSleepStatMediumSleep(accountId), useUninterruptedDuration);
         final List<SleepSegment> reversed = Lists.reverse(sleepSegments);
 
         Integer sleepScore = computeAndMaybeSaveScore(sensorData.trackerMotions, sensorData.originalTrackerMotions, numSoundEvents, allSensorSampleList, targetDate, accountId, sleepStats);
@@ -750,8 +752,7 @@ public class InstrumentedTimelineProcessor extends FeatureFlippedProcessor {
             isValidSleepScore = true;
         }
 
-        final boolean useUninterruptedDuration = useUninterruptedDuration(accountId);
-        final String timeLineMessage = timelineUtils.generateMessage(sleepStats, numPartnerMotion, numSoundEvents, useUninterruptedDuration);
+        final String timeLineMessage = timelineUtils.generateMessage(sleepStats, numPartnerMotion, numSoundEvents);
 
         LOGGER.info("action=compute_sleep_score score={} account_id={}", sleepScore,accountId);
 


### PR DESCRIPTION
FF for uninterrupted sleep was placed where the message was generated. This would have required supichi to access FF to get the correct message. Instead, FF was moved to where sleep stats is computed. 