### PR TITLE
fixed overide pointing to previous NN with new NN endpoint

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/algorithmintegration/NeuralNetFourEventAlgorithm.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/algorithmintegration/NeuralNetFourEventAlgorithm.java
@@ -823,7 +823,7 @@ public class NeuralNetFourEventAlgorithm implements TimelineAlgorithm {
 
     @Override
     public TimelineAlgorithm cloneWithNewUUID(Optional<UUID> uuid) {
-        return new NeuralNetAlgorithm(endpoint);
+        return new NeuralNetFourEventAlgorithm(endpoint);
     }
 
 


### PR DESCRIPTION
fixed bug resulting in skipping new NN algorithm when processed with a uuid - supichi and suripu-queue.

