### PR TITLE
Add new alert type

### DIFF
--- a/suripu-core/src/main/java/com/hello/suripu/core/alerts/Alert.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/alerts/Alert.java
@@ -34,6 +34,10 @@ public class Alert {
         return new Alert(0L, accountId, "Sense Muted", "Sense is currently muted, and will not respond to Voice commands until unmuted.", AlertCategory.SENSE_MUTED, createdAt);
     }
 
+    public static Alert pairingConflict(final Long accountId, final DateTime createdAt) {
+        return Alert.create(0L, accountId, "Remove inactive accounts", "Your Sense may have old, inactive accounts paired to it. Please review and remove inactive accounts.", AlertCategory.REVIEW_ACCOUNTS_PAIRED_TO_SENSE, createdAt);
+    }
+
     @JsonProperty("title")
     public String title() {
         return title;

--- a/suripu-core/src/main/java/com/hello/suripu/core/alerts/AlertCategory.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/alerts/AlertCategory.java
@@ -2,5 +2,6 @@ package com.hello.suripu.core.alerts;
 
 public enum  AlertCategory {
     EXPANSION_UNREACHABLE,
-    SENSE_MUTED
+    SENSE_MUTED,
+    REVIEW_ACCOUNTS_PAIRED_TO_SENSE
 }

--- a/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDAO.java
+++ b/suripu-core/src/main/java/com/hello/suripu/core/db/DeviceDAO.java
@@ -36,6 +36,6 @@ public interface DeviceDAO extends Transactional<DeviceDAO>, DeviceReadDAO {
     @SqlUpdate("DELETE FROM account_device_map WHERE device_id = :device_id and account_id = :account_id;")
     Integer deleteSensePairing(@Bind("device_id") final String senseId, @Bind("account_id") Long accountId);
     
-    @SqlUpdate("UPDATE account_tracker_map set account_id=:account_id WHERE device_id= :device_id")
+    @SqlUpdate("UPDATE account_tracker_map set account_id=:account_id, last_updated = current_timestamp WHERE device_id= :device_id;")
     Integer updateAccountPairedForPill(@Bind("account_id") Long accountId, @Bind("device_id") String pillId);
 }


### PR DESCRIPTION
This is required to support notifying new users that their Sense might have been previously paired to other accounts.